### PR TITLE
feat: Add Music Assistant HelmRelease 

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = .git,.github,magefiles/go.*,kubernetes/flux/config/*,kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml,kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
+ignore-words-list = NotIn,notin
+quiet-level = 3
+check-filenames =

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,4 +46,3 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        entry: codespell -q 3 -f -S ".git,.github,magefiles/go.*,kubernetes/flux/config/*,kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml" README.md

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   # Flux-Kustomizations
   - ./home-assistant/ks.yaml
   - ./mosquitto/ks.yaml
+  - ./music-assistant/ks.yaml

--- a/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
@@ -1,0 +1,122 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: music-assistant
+  namespace: home-automation
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    timeout: 10m
+    replace: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      music-assistant:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/music-assistant/server
+              tag: latest
+            env:
+              TZ: "America/Denver"
+              LOG_LEVEL: "info" # options: critical, error, warning, info, debug
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8095
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8095
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              privileged: true # Required for network discovery
+              capabilities:
+                add:
+                  - DAC_READ_SEARCH
+                  - SYS_ADMIN
+        pod:
+          hostNetwork: true # Required for Music Assistant to discover Sonos speakers
+          dnsPolicy: ClusterFirstWithHostNet
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: NotIn
+                        values:
+                          - k8s6
+    service:
+      app:
+        controller: music-assistant
+        type: LoadBalancer
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: music.techvomit.xyz
+        ports:
+          http:
+            port: 8095
+    ingress:
+      app:
+        className: ingress-traefik
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: music.techvomit.xyz
+        hosts:
+          - host: &host music.techvomit.xyz
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: techvomit-xyz-production-tls
+    persistence:
+      data:
+        enabled: true
+        type: nfs
+        server: 192.168.20.210
+        path: /volume1/k8s/music-assistant
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/home-automation/music-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/music-assistant/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home-automation
+resources:
+  - helmrelease.yaml
+labels:
+  - pairs:
+      app.kubernetes.io/name: music-assistant
+      app.kubernetes.io/instance: music-assistant

--- a/kubernetes/apps/home-automation/music-assistant/ks.yaml
+++ b/kubernetes/apps/home-automation/music-assistant/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app music-assistant
+  namespace: flux-system
+spec:
+  targetNamespace: home-automation
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: nfs-subdir-external-provisioner
+    - name: mosquitto
+  path: ./kubernetes/apps/home-automation/music-assistant/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
**Added:**

- Music Assistant: Added new `music-assistant` HelmRelease using app-template and NFS-based persistence at `kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml`.
- Kustomization: Introduced kustomization resources for Music Assistant app.
- .codespellrc: Added configuration for codespell with custom skip and ignore.
- ks.yaml: Added Flux Kustomization manifest for Music Assistant, including dependencies on NFS provisioner and Mosquitto.

**Changed:**

- Registered `music-assistant` kustomization in the top-level home-automation kustomization at `kubernetes/apps/home-automation/kustomization.yaml`.
- Refactored `.pre-commit-config.yaml` to remove codespell flags handled by the new `.codespellrc` file.

**Removed:**

- Deleted direct codespell arguments from pre-commit hook in `.pre-commit-config.yaml`, replaced with config file.