### PR TITLE
feat: add home assistant grafana dashboard for observability

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/dashboards/home-assistant-dashboard.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/dashboards/home-assistant-dashboard.yaml
@@ -1,0 +1,255 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: home-assistant-dashboard
+  namespace: observability
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Home Assistant"
+    dashboard-version: "1.0.0"
+    last-modified: "2024-08-21"
+data:
+  home-assistant.json: |
+    {
+      "uid": "home-assistant-logs",
+      "title": "Home Assistant Logs & Debugging",
+      "description": "Monitor Home Assistant logs, errors, and warnings",
+      "tags": ["home-assistant", "logs", "debugging"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "pod",
+            "type": "query",
+            "datasource": { "type": "loki", "uid": "loki" },
+            "query": "label_values({namespace=\"home-automation\"}, pod)",
+            "regex": "home-assistant.*",
+            "multi": true,
+            "includeAll": true,
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Recent Errors",
+          "type": "logs",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "{namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"} |= \"ERROR\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending",
+            "prettifyLogMessage": false
+          },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 }
+        },
+        {
+          "id": 2,
+          "title": "Error Rate (5m)",
+          "type": "timeseries",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum by (pod) (rate({namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"} |= \"ERROR\" [5m]))",
+              "refId": "A",
+              "legendFormat": "{{pod}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "errors/sec",
+              "displayName": "Errors per second"
+            }
+          },
+          "gridPos": { "h": 6, "w": 12, "x": 0, "y": 8 }
+        },
+        {
+          "id": 3,
+          "title": "Total Errors (Last Hour)",
+          "type": "stat",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"} |= \"ERROR\" [1h]))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 50 }
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": { "h": 6, "w": 6, "x": 12, "y": 8 }
+        },
+        {
+          "id": 4,
+          "title": "Total Warnings (Last Hour)",
+          "type": "stat",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"} |= \"WARNING\" [1h]))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 25 },
+                  { "color": "orange", "value": 100 }
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": { "h": 6, "w": 6, "x": 18, "y": 8 }
+        },
+        {
+          "id": 5,
+          "title": "Warnings",
+          "type": "logs",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "{namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"} |= \"WARNING\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": false,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 14 }
+        },
+        {
+          "id": 6,
+          "title": "Integration Logs (custom_components)",
+          "type": "logs",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "{namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"} |= \"custom_components\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 }
+        },
+        {
+          "id": 7,
+          "title": "Log Volume Over Time",
+          "type": "graph",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum(rate({namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"} [5m])) by (level)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              },
+              "unit": "logs/sec"
+            }
+          },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 }
+        },
+        {
+          "id": 8,
+          "title": "All Logs (Live)",
+          "type": "logs",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "{namespace=\"home-automation\",app=\"home-assistant\",pod=~\"$pod\"}",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 36 }
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: observability
 resources:
   - externalsecret.yaml
   - helmrelease.yaml
+  - dashboards/home-assistant-dashboard.yaml


### PR DESCRIPTION
**Added:**

- Introduced a new Grafana dashboard for Home Assistant logs and debugging as a ConfigMap, enabling visibility into errors, warnings, and log volume using Loki data sources
- Registered the Home Assistant dashboard in the kustomization resources for deployment with kube-prometheus-stack

**Changed:**

- Updated `kustomization.yaml` to include the Home Assistant dashboard in the list of managed resources for the observability namespace