### PR TITLE
feat: enable ingress for loki with traefik and tls configuration

### DIFF
--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -86,6 +86,15 @@ spec:
       enabled: true
       replicas: 1
       verboseLogging: true
+      ingress:
+        enabled: true
+        ingressClassName: ingress-traefik
+        pathType: Prefix
+        hosts:
+          - &host loki.techvomit.xyz
+        tls:
+          - hosts:
+              - *host
 
     monitoring:
       dashboards:


### PR DESCRIPTION
**Added:**

- Enabled ingress for the Loki deployment with `ingress-traefik` class, set pathType to Prefix, defined host as `loki.techvomit.xyz`, and configured TLS for secure access in the HelmRelease manifest