### PR TITLE
ci: add helm installation and bootstrap CRD step to test workflow

### DIFF
--- a/.github/workflows/test-manifests.yaml
+++ b/.github/workflows/test-manifests.yaml
@@ -93,11 +93,21 @@ jobs:
           sudo mv helmfile /usr/local/bin/
           helmfile version
 
+      - name: Install Helm
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          helm version
+
       - name: Create test cluster
         run: task -y test:create
 
       - name: Install Flux in test cluster
         run: task -y test:install-flux
+
+      - name: Install bootstrap CRDs
+        run: |
+          helmfile -f kubernetes/bootstrap/helmfile.d/00-crds.yaml template -q \
+            | kubectl apply --server-side --force-conflicts -f -
 
       - name: Apply testable apps
         run: task -y test:apply


### PR DESCRIPTION
**Key Changes:**

- Added step to install Helm in the CI test workflow
- Introduced step to install bootstrap CRDs using Helmfile and kubectl
- Enhanced cluster setup to ensure required CRDs are present before applying testable apps

**Added:**

- Helm installation step - Installs Helm v3 via official script in the test workflow to ensure Helm is available for subsequent steps
- Bootstrap CRD installation - Runs Helmfile templating for bootstrap CRDs and applies them with kubectl to support resources needed by testable apps

**Changed:**

- Test workflow sequence - Adjusted the order of operations to install Helm and CRDs prior to applying testable applications, improving reliability of test setup