### PR TITLE
feat: add blackbox-exporter and robusta for improved cluster recovery observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ keys.txt
 
 # VSCode artifacts
 node_modules
+
+# Local Claude Code config
+.claude/

--- a/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-blackbox-exporter
+  namespace: observability
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: prometheus-blackbox-exporter
+    namespace: observability
+  install:
+    timeout: 10m
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+
+  values:
+    fullnameOverride: blackbox-exporter
+
+    config:
+      modules:
+        tcp_connect:
+          prober: tcp
+          timeout: 5s
+        http_2xx:
+          prober: http
+          timeout: 5s
+          http:
+            preferred_ip_protocol: ip4
+            valid_status_codes: []
+        icmp:
+          prober: icmp
+          timeout: 5s
+          icmp:
+            preferred_ip_protocol: ip4
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 96Mi
+
+    serviceMonitor:
+      enabled: false
+
+    pspEnabled: false
+
+    allowIcmp: true

--- a/kubernetes/apps/observability/blackbox-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./probes.yaml
+  - ./rules.yaml

--- a/kubernetes/apps/observability/blackbox-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: prometheus-blackbox-exporter
+  namespace: observability
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 9.4.0
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter

--- a/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: nas-nfs
+  namespace: observability
+spec:
+  interval: 30s
+  scrapeTimeout: 10s
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      static:
+        - 192.168.20.210:2049
+      labels:
+        target: synology-nas
+        port_role: nfs
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: kube-api-vip
+  namespace: observability
+spec:
+  interval: 30s
+  scrapeTimeout: 10s
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      static:
+        - 192.168.20.150:6443
+      labels:
+        target: kube-api-vip
+        port_role: kubernetes-api
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: signal-bridge
+  namespace: observability
+spec:
+  interval: 60s
+  scrapeTimeout: 10s
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      static:
+        - 192.168.20.45:8080
+      labels:
+        target: signal-bridge
+        port_role: alert-delivery

--- a/kubernetes/apps/observability/blackbox-exporter/app/rules.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/rules.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: blackbox-rules
+  namespace: observability
+spec:
+  groups:
+    - name: blackbox.probes
+      rules:
+        - alert: NFSServerUnreachable
+          annotations:
+            summary: Synology NAS NFS port not reachable
+            description: |
+              TCP probe to {{ $labels.instance }} (NFS 2049) has been failing
+              for 2m. Most cluster PVCs depend on this NAS — workloads will
+              start failing to mount on restart.
+          expr: probe_success{target="synology-nas",port_role="nfs"} == 0
+          for: 2m
+          labels:
+            severity: critical
+
+        - alert: KubeApiVipUnreachable
+          annotations:
+            summary: Kubernetes API VIP not reachable
+            description: |
+              TCP probe to {{ $labels.instance }} (kube-apiserver VIP) has
+              been failing for 1m. Either kube-vip failed to fail over or
+              all masters are down.
+          expr: probe_success{target="kube-api-vip"} == 0
+          for: 1m
+          labels:
+            severity: critical
+
+        - alert: SignalBridgeUnreachable
+          annotations:
+            summary: Signal bridge LXC not reachable
+            description: |
+              Alertmanager will not be able to deliver Signal notifications.
+              Pushover continues to deliver. Check LXC 109 on proxmox.
+          expr: probe_success{target="signal-bridge"} == 0
+          for: 5m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app blackbox-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kube-prometheus-stack
+  path: ./kubernetes/apps/observability/blackbox-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 15m

--- a/kubernetes/apps/observability/grafana/app/dashboards/cluster-recovery-dashboard.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/cluster-recovery-dashboard.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-recovery-dashboard
+  namespace: observability
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: Recovery
+    description: At-a-glance recovery view — what's stuck and what's stalled
+data:
+  cluster-recovery.json: |
+    {
+      "title": "Cluster Recovery",
+      "uid": "cluster-recovery",
+      "tags": ["recovery", "incident", "cluster"],
+      "schemaVersion": 39,
+      "timezone": "browser",
+      "refresh": "30s",
+      "time": { "from": "now-1h", "to": "now" },
+      "templating": {
+        "list": [
+          { "name": "datasource", "type": "datasource", "query": "prometheus", "hide": 0 }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Control-plane masters Ready",
+          "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "targets": [{
+            "expr": "count(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1 and on (node) kube_node_role{role=\"control-plane\"})",
+            "refId": "A"
+          }],
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "graphMode": "none",
+            "textMode": "value_and_name",
+            "colorMode": "background"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "red", "value": null},
+                  {"color": "yellow", "value": 2},
+                  {"color": "green", "value": 3}
+                ]
+              },
+              "unit": "none",
+              "min": 0, "max": 3
+            }
+          }
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Worker nodes Ready",
+          "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "targets": [{
+            "expr": "count(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1 unless on (node) kube_node_role{role=\"control-plane\"}) / count(kube_node_info unless on (node) kube_node_role{role=\"control-plane\"})",
+            "refId": "A",
+            "format": "time_series"
+          }, {
+            "expr": "count(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1 unless on (node) kube_node_role{role=\"control-plane\"})",
+            "refId": "B"
+          }],
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "/B/", "values": false},
+            "graphMode": "none",
+            "colorMode": "background"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "red", "value": null},
+                  {"color": "yellow", "value": 4},
+                  {"color": "green", "value": 5}
+                ]
+              },
+              "unit": "none"
+            }
+          }
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "NAS NFS reachable",
+          "gridPos": {"h": 5, "w": 6, "x": 12, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "targets": [{
+            "expr": "probe_success{target=\"synology-nas\",port_role=\"nfs\"}",
+            "refId": "A"
+          }],
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {"type": "value", "options": {"0": {"text": "DOWN", "color": "red"}, "1": {"text": "UP", "color": "green"}}}
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "red", "value": null},
+                  {"color": "green", "value": 1}
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "kube-api VIP reachable",
+          "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "targets": [{
+            "expr": "probe_success{target=\"kube-api-vip\"}",
+            "refId": "A"
+          }],
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {"type": "value", "options": {"0": {"text": "DOWN", "color": "red"}, "1": {"text": "UP", "color": "green"}}}
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "red", "value": null},
+                  {"color": "green", "value": 1}
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": 5,
+          "type": "table",
+          "title": "Stuck pods",
+          "description": "Terminating with deletionTimestamp set (likely on a NotReady node — force-delete), Pending too long, or CrashLoopBackOff",
+          "gridPos": {"h": 10, "w": 12, "x": 0, "y": 5},
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "targets": [
+            {
+              "expr": "kube_pod_deletion_timestamp",
+              "refId": "Terminating",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "Terminating"
+            },
+            {
+              "expr": "kube_pod_status_phase{phase=\"Pending\"} == 1",
+              "refId": "Pending",
+              "format": "table",
+              "instant": true
+            },
+            {
+              "expr": "max_over_time(kube_pod_container_status_waiting_reason{reason=\"CrashLoopBackOff\"}[5m]) >= 1",
+              "refId": "CrashLooping",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "transformations": [
+            {"id": "merge", "options": {}},
+            {"id": "organize", "options": {
+              "excludeByName": {"Time": true, "__name__": true, "job": true, "service": true, "endpoint": true, "container": true, "uid": true, "instance": true, "prometheus": true, "cluster": true},
+              "renameByName": {"namespace": "ns", "pod": "pod", "phase": "phase", "reason": "reason"}
+            }}
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {"align": "auto", "displayMode": "auto"}
+            }
+          }
+        },
+        {
+          "id": 6,
+          "type": "table",
+          "title": "Flux reconcile failures",
+          "description": "Kustomization or HelmRelease with Ready=False",
+          "gridPos": {"h": 10, "w": 12, "x": 12, "y": 5},
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "targets": [{
+            "expr": "max(gotk_reconcile_condition{status=\"False\",type=\"Ready\"}) by (namespace, name, kind) == 1",
+            "refId": "A",
+            "format": "table",
+            "instant": true
+          }],
+          "transformations": [
+            {"id": "organize", "options": {
+              "excludeByName": {"Time": true, "__name__": true, "job": true, "service": true, "endpoint": true, "container": true, "uid": true, "instance": true, "prometheus": true, "cluster": true, "status": true, "type": true, "Value": true},
+              "indexByName": {"kind": 0, "namespace": 1, "name": 2}
+            }}
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {"align": "auto", "displayMode": "auto"}
+            }
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - ./dashboards/throwingshade-operations-dashboard.yaml
   - ./dashboards/troy-backup-dashboard.yaml
   - ./dashboards/adguard-iphone-dns-dashboard.yaml
+  - ./dashboards/cluster-recovery-dashboard.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -31,11 +31,27 @@ spec:
       - receiver: pushover
         groupWait: 0s
         repeatInterval: 1h
+        continue: true
+        matchers:
+          - name: severity
+            value: critical
+            matchType: =
+      - receiver: signal
+        groupWait: 0s
+        repeatInterval: 1h
         matchers:
           - name: severity
             value: critical
             matchType: =
       - receiver: pushover
+        groupWait: 5m
+        repeatInterval: 6h
+        continue: true
+        matchers:
+          - name: severity
+            value: warning
+            matchType: =
+      - receiver: signal
         groupWait: 5m
         repeatInterval: 6h
         matchers:
@@ -56,6 +72,10 @@ spec:
           matchType: =
   receivers:
     - name: "null"
+    - name: signal
+      webhookConfigs:
+        - url: http://192.168.20.45:8081/
+          sendResolved: true
     - name: pushover
       pushoverConfigs:
         - html: true

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./poddisruptionbudget.yaml
+  - ./recovery-rules.yaml
   - ./scrapeconfig.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/recovery-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/recovery-rules.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: recovery-rules
+  namespace: observability
+spec:
+  groups:
+    - name: recovery.cluster
+      rules:
+        - alert: PodStuckTerminating
+          annotations:
+            summary: Pod stuck Terminating > 15m
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} has had a deletion
+              timestamp set for {{ $value | humanizeDuration }}. Likely on a
+              NotReady node — force-delete with `kubectl delete pod --force`.
+          expr: |
+            time() - kube_pod_deletion_timestamp > 900
+          for: 5m
+          labels:
+            severity: warning
+
+        - alert: ControlPlaneMasterDown
+          annotations:
+            summary: Control-plane master not Ready
+            description: |
+              {{ $value }} of 3 control-plane masters are Ready. etcd quorum
+              still holds (needs 2/3) but is one failure away from API loss.
+          expr: |
+            count(
+              kube_node_status_condition{condition="Ready", status="true"} == 1
+                and on (node) kube_node_role{role="control-plane"}
+            ) < 3
+          for: 5m
+          labels:
+            severity: warning
+
+        - alert: ControlPlaneQuorumLost
+          annotations:
+            summary: etcd quorum LOST — API server unwritable
+            description: |
+              Only {{ $value }} of 3 control-plane masters Ready. etcd has lost
+              quorum; API returns ServiceUnavailable. Restore at least one of
+              the down masters immediately.
+          expr: |
+            count(
+              kube_node_status_condition{condition="Ready", status="true"} == 1
+                and on (node) kube_node_role{role="control-plane"}
+            ) < 2
+          for: 1m
+          labels:
+            severity: critical

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -7,10 +7,12 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./alloy/ks.yaml
+  - ./blackbox-exporter/ks.yaml
   - ./goldilocks/ks.yaml
   - ./grafana/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
+  - ./robusta/ks.yaml
   - ./tempo/ks.yaml
   - ./unpoller/ks.yaml
   - ./vector/ks.yaml

--- a/kubernetes/apps/observability/robusta/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/robusta/app/helmrelease.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: robusta
+  namespace: observability
+spec:
+  interval: 1h
+  timeout: 15m
+  chart:
+    spec:
+      chart: robusta
+      # Pinned to a recent stable OSS release of Robusta.
+      # Robusta publishes multi-arch images (amd64 + arm64) on its public registry
+      # since 0.10.x; arm64 RPI nodes (k8s7) are supported. If a future bump regresses
+      # arm64 support, fall back to nodeSelector kubernetes.io/hostname: k8s8 (amd64 VM).
+      version: 0.18.6
+      sourceRef:
+        kind: HelmRepository
+        name: robusta
+        namespace: observability
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # ---------------------------------------------------------------------------
+    # Open-source Robusta only. No SaaS account, no signing_key, no account_id.
+    # Disable platform integration so we don't accidentally call out to robusta.dev.
+    # ---------------------------------------------------------------------------
+    enablePlatformPlaybooks: false
+    disableCloudRouting: true
+    enablePrometheusStack: false
+    enabledManagedConfiguration: false
+
+    globalConfig:
+      cluster_name: woe
+      # Reuse the existing in-cluster kube-prometheus-stack endpoints.
+      alertmanager_url: http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093
+      prometheus_url: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+      grafana_url: ""
+
+    # ---------------------------------------------------------------------------
+    # Sinks: a single webhook that POSTs alert events to the Signal adapter LXC,
+    # the same target Alertmanager already uses for its `signal` receiver.
+    # ---------------------------------------------------------------------------
+    sinksConfig:
+      - webhook_sink:
+          name: signal_adapter
+          url: http://192.168.20.45:8081/
+          # Forward all severities; the adapter does any final filtering.
+          stop: false
+
+    # ---------------------------------------------------------------------------
+    # Custom playbooks (action triggers) layered on top of the chart defaults.
+    # ---------------------------------------------------------------------------
+    customPlaybooks:
+      # 1. PodStuckTerminating -> force delete the pod (grace_period=0).
+      #    `delete_pod` is a built-in Robusta action.
+      - triggers:
+          - on_prometheus_alert:
+              alert_name: PodStuckTerminating
+        actions:
+          - delete_pod:
+              grace_period_seconds: 0
+        sinks:
+          - signal_adapter
+
+      # 2. FluxReconciliationFailure -> kick a Flux reconcile by annotating the
+      #    failing resource with reconcile.fluxcd.io/requestedAt=<now>.
+      #
+      #    NOTE / UNCERTAINTY: Robusta does not ship a dedicated built-in
+      #    "kick-flux-reconcile" action. The closest built-ins are
+      #    `resource_events_enricher` / `alert_explanation_enricher` (informational
+      #    only). To actually re-trigger Flux we would need either:
+      #      a) a custom Python action (explicitly out of scope here), or
+      #      b) the generic `node_bash_enricher` / a future `kubectl_action` style
+      #         built-in.
+      #    For now we fire the well-known logging/enrichment actions so the alert
+      #    is still routed to Signal with context, and leave a TODO to wire a
+      #    real reconcile-kick action when one exists.
+      - triggers:
+          - on_prometheus_alert:
+              alert_name: FluxReconciliationFailure
+        actions:
+          - logs_enricher: {}
+          - resource_events_enricher: {}
+        sinks:
+          - signal_adapter
+
+    # ---------------------------------------------------------------------------
+    # Pin to k8s7 (Ready arm64 RPI, 8GB) and avoid k8s9 (cordoned/unstable).
+    # ---------------------------------------------------------------------------
+    runner:
+      sendAdditionalTelemetry: false
+      nodeSelector:
+        kubernetes.io/hostname: k8s7
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+
+    kubewatch:
+      nodeSelector:
+        kubernetes.io/hostname: k8s7
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+
+    grafanaRenderer:
+      enabled: false

--- a/kubernetes/apps/observability/robusta/app/helmrepository.yaml
+++ b/kubernetes/apps/observability/robusta/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: robusta
+  namespace: observability
+spec:
+  interval: 2h
+  url: https://robusta-charts.storage.googleapis.com

--- a/kubernetes/apps/observability/robusta/app/kustomization.yaml
+++ b/kubernetes/apps/observability/robusta/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/robusta/ks.yaml
+++ b/kubernetes/apps/observability/robusta/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app robusta
+  namespace: flux-system
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kube-prometheus-stack
+  path: ./kubernetes/apps/observability/robusta/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 15m


### PR DESCRIPTION
**Key Changes:**

- Introduced blackbox-exporter for external service probing and alerting
- Added Robusta OSS automation for cluster recovery playbooks
- Added a dedicated cluster recovery Grafana dashboard
- Refined Alertmanager routing for critical and warning severities, adding a Signal webhook receiver

**Added:**

- Blackbox-exporter deployment (HelmRelease, OCIRepository, Kustomization), with Probes for NAS NFS port (192.168.20.210:2049), kube-api VIP (192.168.20.150:6443), and the off-cluster Signal bridge LXC, plus PrometheusRule alerts (NFSServerUnreachable critical, KubeApiVipUnreachable critical, SignalBridgeUnreachable warning).
- Robusta OSS deployment (HelmRepository + HelmRelease), cloud-routing disabled. Playbooks for force-deleting stuck Terminating pods on PodStuckTerminating, and enrichment of FluxReconciliationFailure events. Webhook sink to the Signal adapter at 192.168.20.45:8081. Pinned to k8s7 (arm64 RPI), small resource footprint.
- Cluster recovery Grafana dashboard in the new Recovery folder: control-plane quorum stat, worker-Ready stat, NAS/API VIP probe stats, plus Stuck Pods and Flux reconcile failures tables.
- PrometheusRule recovery-rules.yaml in kube-prometheus-stack: PodStuckTerminating, ControlPlaneMasterDown (warning), ControlPlaneQuorumLost (critical).
- Robusta and blackbox-exporter Flux Kustomization entries in observability aggregator.
- .claude/ added to .gitignore.

**Changed:**

- AlertmanagerConfig (kube-prometheus-stack/app/alertmanagerconfig.yaml): added Signal webhook receiver pointing at the off-cluster Signal bridge adapter (192.168.20.45:8081). Existing Pushover routes preserved with continue: true so critical and warning alerts now dual-deliver to Pushover and Signal.

**Notes:**

- Robusta arm64 image at chart 0.18.6 not live-probed; if pod fails to start on k8s7 swap nodeSelector to k8s8 (amd64 VM).
- FluxReconciliationFailure playbook only enriches and notifies — actual reconcile-kicking would need a custom Robusta Python action, deferred.
- Helm release schema fixes for ollama and ingress-traefik are intentionally **not** in this PR; they ship separately.