### PR TITLE
fix: correct port definition and cleanup traefik helmrelease configuration

### DIFF
--- a/kubernetes/apps/inference/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/inference/ollama/app/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
               OLLAMA_CONTEXT_LENGTH: "8192"
               OLLAMA_DEBUG: "true"
             ports:
-              http:
+              - name: http
                 containerPort: 11434
                 protocol: TCP
             probes:

--- a/kubernetes/apps/networking/ingress-traefik/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/ingress-traefik/app/helmrelease.yaml
@@ -50,7 +50,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    revisionHistoryLimit: 3
     # Core configs
     image:
       registry: ghcr.io
@@ -91,7 +90,7 @@ spec:
         loadBalancerIP: 192.168.20.10
         externalTrafficPolicy: Local
 
-    extraEnvs:
+    env:
       - name: TZ
         value: "America/Denver"
 
@@ -136,16 +135,6 @@ spec:
       limits:
         memory: 500Mi
 
-    pilot:
-      enabled: false
-
-    restartPolicy: Always
-
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
     persistence:
       config:
         enabled: true
@@ -188,6 +177,3 @@ spec:
         expose:
           default: true
         exposedPort: 443
-        tls:
-          enabled: true
-          options: "default"


### PR DESCRIPTION
**Key Changes:**

- Fixed port definition format for Ollama HelmRelease to match expected syntax
- Refactored ingress-traefik HelmRelease by removing redundant and deprecated configuration fields
- Switched from `extraEnvs` to `env` for environment variable declaration in ingress-traefik

**Changed:**

- Port specification for Ollama - Replaced object-based `ports.http` with list item to ensure valid HelmRelease manifest
- Ingress-traefik configuration - Removed obsolete fields such as `revisionHistoryLimit`, `pilot.enabled`, `restartPolicy`, and `dnsConfig` to streamline configuration and prevent potential conflicts
- Environment variables handling in ingress-traefik - Changed from `extraEnvs` to standard `env` block for clarity and compatibility
- Traefik dashboard TLS settings - Removed `tls.enabled` and `options` under dashboard, likely shifting to default or external TLS management