### PR TITLE
feat: upgrade robusta helm chart to version 0.38.0

### DIFF
--- a/kubernetes/apps/observability/robusta/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/robusta/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       # Robusta publishes multi-arch images (amd64 + arm64) on its public registry
       # since 0.10.x; arm64 RPI nodes (k8s7) are supported. If a future bump regresses
       # arm64 support, fall back to nodeSelector kubernetes.io/hostname: k8s8 (amd64 VM).
-      version: 0.18.6
+      version: 0.38.0
       sourceRef:
         kind: HelmRepository
         name: robusta


### PR DESCRIPTION
**Key Changes:**

- Updated robusta helm chart version from 0.18.6 to 0.38.0
- Enables access to new features, bug fixes, and improvements introduced in upstream robusta releases

**Changed:**

- Robusta deployment version - Upgraded the `spec.chart.spec.version` in `helmrelease.yaml` to 0.38.0 to leverage recent upstream enhancements and maintain support for multi-arch images