### PR TITLE
fix: set clusterName at root level in robusta helmrelease

### DIFF
--- a/kubernetes/apps/observability/robusta/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/robusta/app/helmrelease.yaml
@@ -37,8 +37,9 @@ spec:
     enablePrometheusStack: false
     enabledManagedConfiguration: false
 
+    clusterName: woe
+
     globalConfig:
-      cluster_name: woe
       # Reuse the existing in-cluster kube-prometheus-stack endpoints.
       alertmanager_url: http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093
       prometheus_url: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090


### PR DESCRIPTION
**Key Changes:**

- Moved cluster name configuration from globalConfig to root level
- Ensured clusterName is set explicitly for robusta deployment

**Changed:**

- Cluster name configuration location - Relocated the cluster name from `globalConfig.cluster_name` to the root-level `clusterName` field in `helmrelease.yaml` to align with expected configuration structure and prevent misconfiguration