### PR TITLE
feat: add ares cracker agent with remote hashcat support

### DIFF
--- a/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
@@ -39,7 +39,9 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: agent
-          image: ghcr.io/dreadnode/ares-cracker-agent:latest
+          # Pulls from the fork's GHCR until the remote-hashcat patch
+          # (l50/ares#9) lands upstream and dreadnode rebuilds.
+          image: ghcr.io/l50/ares-cracker-agent:latest
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ares-cracker-agent
+  namespace: attack-simulation
+  labels:
+    app.kubernetes.io/name: ares-cracker-agent
+    app.kubernetes.io/part-of: attack-simulation
+    ares.dreadnode.io/role: cracker
+    ares.dreadnode.io/component: red-team
+spec:
+  serviceName: ares-cracker-agent
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ares-cracker-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ares-cracker-agent
+        app.kubernetes.io/part-of: attack-simulation
+        ares.dreadnode.io/role: cracker
+        ares.dreadnode.io/component: red-team
+    spec:
+      serviceAccountName: ares-agent
+      imagePullSecrets:
+        - name: ghcr-auth
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/part-of: attack-simulation
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: agent
+          image: ghcr.io/dreadnode/ares-cracker-agent:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                ares worker cracker --redis-url "redis://:${REDIS_PASSWORD}@redis.attack-simulation.svc.cluster.local:6379"
+                status=$?
+                echo "ares worker exited with status $status; restarting in 5s" >&2
+                sleep 5
+              done
+          stdin: true
+          tty: true
+          env:
+            - name: ARES_ROLE
+              value: "cracker"
+            - name: ARES_CONFIG
+              value: "/etc/ares/ares.yaml"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ares-llm-secret
+                  key: OPENAI_API_KEY
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_SERVICE_NAME
+              value: "ares-cracker"
+            # Remote hashcat backend — delegates crack_with_hashcat to the
+            # crackd service running on the macOS host (M1 Max GPU via Metal).
+            # Requires the dreadnode/ares PR adding remote hashcat support.
+            - name: HASHCAT_SERVICE_URL
+              value: "http://hashcat.cracking.svc.cluster.local:8787"
+            - name: HASHCAT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hashcat-token
+                  key: token
+          envFrom:
+            - configMapRef:
+                name: ares-agent-config
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/ares
+            - name: workspace
+              mountPath: /ares
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pgrep -f 'ares worker'"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pgrep -f 'ares worker'"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+      volumes:
+        - name: config
+          configMap:
+            name: ares-config
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: nfs-client
+        resources:
+          requests:
+            storage: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ares-cracker-agent
+  namespace: attack-simulation
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: ares-cracker-agent
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
@@ -39,8 +39,8 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: agent
-          # Pulls from the fork's GHCR until the remote-hashcat patch
-          # (l50/ares#9) lands upstream and dreadnode rebuilds.
+          # Built from l50/ares (fork carries the remote-hashcat patch).
+          # Swap back to ghcr.io/dreadnode/... if/when the patch lands upstream.
           image: ghcr.io/l50/ares-cracker-agent:latest
           command: ["/bin/sh", "-c"]
           args:

--- a/kubernetes/apps/attack-simulation/ares/app/externalsecret-hashcat.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/externalsecret-hashcat.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hashcat-token
+  namespace: attack-simulation
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshInterval: 1h
+  target:
+    name: hashcat-token
+  data:
+    - secretKey: token
+      remoteRef:
+        key: "hashcat"
+        property: token

--- a/kubernetes/apps/attack-simulation/ares/app/kustomization.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - externalsecret-redis.yaml
   - externalsecret-llm.yaml
   - externalsecret-grafana.yaml
+  - externalsecret-hashcat.yaml
   # Infrastructure
   - redis-configmap.yaml
   - redis-statefulset.yaml
@@ -24,6 +25,7 @@ resources:
   - agents/privesc.yaml
   - agents/lateral-movement.yaml
   - agents/coercion.yaml
+  - agents/cracker.yaml
   # Blue Team Agents
   - agents/blue-orchestrator.yaml
   - agents/blue-triage.yaml


### PR DESCRIPTION
**Key Changes:**

- Added a dedicated Ares cracker agent for password-cracking attack simulation workflows
- Integrated the cracker agent with the remote hashcat service for GPU-backed cracking
- Added external secret management for the hashcat service token
- Registered the new cracker resources in the Ares application deployment

**Added:**

- Cracker agent workload - Added a StatefulSet and headless Service in kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml to run ares worker cracker with Redis connectivity, persistent workspace storage, health probes, resource limits, pod anti-affinity, and remote hashcat environment configuration
- Hashcat token secret sync - Added kubernetes/apps/attack-simulation/ares/app/externalsecret-hashcat.yaml to pull the hashcat token from the onepassword-connect ClusterSecretStore into the attack-simulation namespace

**Changed:**

- Ares application composition - Updated kubernetes/apps/attack-simulation/ares/app/kustomization.yaml to include the new hashcat ExternalSecret and cracker agent resources so they are deployed with the rest of the attack-simulation stack