### PR TITLE
fix: extend system upgrade job timeout

### DIFF
--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/plans/agent.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/plans/agent.yaml
@@ -10,7 +10,7 @@ spec:
   version: "v1.36.1+k3s1"
   serviceAccountName: system-upgrade
   concurrency: 1
-  jobActiveDeadlineSecs: 1800 # 30 minutes timeout for upgrade jobs
+  jobActiveDeadlineSecs: 3600 # 60 minutes — agents host many pods; drain can exceed 30m
   nodeSelector:
     matchExpressions:
       - { key: node-role.kubernetes.io/control-plane, operator: DoesNotExist }

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/plans/server.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/plans/server.yaml
@@ -10,7 +10,7 @@ spec:
   version: "v1.36.1+k3s1"
   serviceAccountName: system-upgrade
   concurrency: 1
-  jobActiveDeadlineSecs: 1800 # 30 minutes timeout for upgrade jobs
+  jobActiveDeadlineSecs: 3600 # 60 minutes — drain can exceed 30m on busy control planes
   cordon: true
   nodeSelector:
     matchExpressions:


### PR DESCRIPTION
**Key Changes:**

- Increased system upgrade job deadline from 30 minutes to 60 minutes
- Reduced risk of upgrade failures when node drains exceed the previous timeout
- Applied the longer timeout consistently across both agent and server upgrade plans

**Changed:**

- System upgrade plan timeout - Updated `jobActiveDeadlineSecs` from `1800` to `3600` in the agent and server plans to allow busy nodes and control planes more time to drain before upgrade jobs are terminated
- Timeout documentation - Adjusted inline comments to clarify why the 60-minute deadline is needed for agents hosting many pods and busy control plane nodes