### PR TITLE
ci: pin kustomize installation in manifest tests

### DIFF
--- a/.github/workflows/test-manifests.yaml
+++ b/.github/workflows/test-manifests.yaml
@@ -21,6 +21,7 @@ env:
   KUBECTL_VERSION: v1.31.4
   FLUX_VERSION: v2.4.0
   HELMFILE_VERSION: v1.0.0-rc.1
+  KUSTOMIZE_VERSION: v5.8.1
 
 permissions:
   contents: read
@@ -41,8 +42,11 @@ jobs:
 
       - name: Install kustomize
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          curl --fail --location --retry 5 --retry-all-errors --retry-delay 5 -o kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${{ env.KUSTOMIZE_VERSION }}/kustomize_${{ env.KUSTOMIZE_VERSION }}_linux_amd64.tar.gz"
+          tar -xzf kustomize.tar.gz
           sudo mv kustomize /usr/local/bin/
+          rm kustomize.tar.gz
           kustomize version
 
       - name: Validate manifests


### PR DESCRIPTION
**Key Changes:**

- Pinned the kustomize version used by manifest validation to improve CI reproducibility
- Replaced the upstream install script with a direct release archive download
- Added retry and failure handling to make kustomize installation more resilient

**Added:**

- Kustomize version configuration - Added `KUSTOMIZE_VERSION` to the workflow environment so the CI toolchain version is explicit and easy to update

**Changed:**

- Kustomize installation flow - Updated the manifest test workflow to download the pinned release archive directly, extract the binary, move it into the PATH, and clean up the temporary archive
- Download reliability - Added curl failure detection, redirects, retries, retry-all-errors, and retry delay options to reduce transient CI failures

**Removed:**

- Unpinned install script dependency - Removed reliance on the upstream `install_kustomize.sh` script from the master branch to avoid unexpected version changes or script behavior changes