### PR TITLE
fix: disable helm wait for authentik release operations

### DIFF
--- a/kubernetes/apps/identity/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/identity/authentik/app/helmrelease.yaml
@@ -17,10 +17,12 @@ spec:
         namespace: identity
   install:
     timeout: 30m
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
     timeout: 30m
+    disableWait: true
     cleanupOnFail: true
     remediation:
       strategy: rollback


### PR DESCRIPTION
**Key Changes:**

- Disabled Helm wait behavior for authentik installs and upgrades
- Preserved existing 30-minute timeouts and remediation retry settings
- Kept upgrade cleanup and rollback behavior while avoiding blocked reconciliations

**Added:**

- Helm install and upgrade disableWait settings for the authentik release - kubernetes/apps/identity/authentik/app/helmrelease.yaml

**Changed:**

- Authentik release reconciliation now skips waiting for resources to become ready during install and upgrade operations, helping prevent Flux from stalling on long-running or delayed readiness checks