### PR TITLE
fix: remove authentik worker health probes

### DIFF
--- a/kubernetes/apps/identity/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/identity/authentik/app/helmrelease.yaml
@@ -244,42 +244,6 @@ spec:
                     app.kubernetes.io/component: primary
                 topologyKey: kubernetes.io/hostname
 
-      startupProbe:
-        exec:
-          command:
-            - sh
-            - -c
-            - test -f /dev/shm/authentik-worker.pid && kill -0 $(cat /dev/shm/authentik-worker.pid)
-        initialDelaySeconds: 120
-        periodSeconds: 10
-        timeoutSeconds: 10
-        failureThreshold: 90
-        successThreshold: 1
-
-      livenessProbe:
-        exec:
-          command:
-            - sh
-            - -c
-            - test -f /dev/shm/authentik-worker.pid && kill -0 $(cat /dev/shm/authentik-worker.pid)
-        initialDelaySeconds: 60
-        periodSeconds: 10
-        timeoutSeconds: 10
-        failureThreshold: 3
-        successThreshold: 1
-
-      readinessProbe:
-        exec:
-          command:
-            - sh
-            - -c
-            - test -f /dev/shm/authentik-worker.pid && kill -0 $(cat /dev/shm/authentik-worker.pid)
-        initialDelaySeconds: 30
-        periodSeconds: 10
-        timeoutSeconds: 10
-        failureThreshold: 3
-        successThreshold: 1
-
       # Worker metrics disabled - authentik workers do not expose metrics endpoint
       metrics:
         enabled: false


### PR DESCRIPTION
**Key Changes:**

- Removed custom startup, liveness, and readiness probes from the authentik worker configuration
- Eliminated PID-file based health checks that depended on `/dev/shm/authentik-worker.pid`
- Kept worker metrics disabled because authentik workers do not expose a metrics endpoint

**Removed:**

- Authentik worker probe configuration - Removed startup, liveness, and readiness exec probes from `kubernetes/apps/identity/authentik/app/helmrelease.yaml` to stop relying on PID-file checks for worker health validation