### PR TITLE
fix: enable helm readiness waiting for authentik

### DIFF
--- a/kubernetes/apps/identity/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/identity/authentik/app/helmrelease.yaml
@@ -17,12 +17,10 @@ spec:
         namespace: identity
   install:
     timeout: 30m
-    disableWait: true
     remediation:
       retries: 3
   upgrade:
     timeout: 30m
-    disableWait: true
     cleanupOnFail: true
     remediation:
       strategy: rollback


### PR DESCRIPTION
**Key Changes:**

- Restored default Helm wait behavior for authentik installs and upgrades
- Ensured Flux waits for resources to become ready before marking releases successful
- Kept existing timeout, retry, rollback, and cleanup behavior unchanged

**Changed:**

- Authentik Helm release lifecycle handling - Removed `disableWait: true` from install and upgrade settings in `kubernetes/apps/identity/authentik/app/helmrelease.yaml` so deployments properly wait for readiness while retaining existing remediation safeguards