### PR TITLE
feat: add macworker node affinity and laptop toleration to ares agents

### DIFF
--- a/kubernetes/apps/attack-simulation/ares/app/agents/acl.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/acl.yaml
@@ -37,6 +37,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -45,6 +53,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:

--- a/kubernetes/apps/attack-simulation/ares/app/agents/blue-lateral-analyst.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/blue-lateral-analyst.yaml
@@ -37,6 +37,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -45,6 +53,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:

--- a/kubernetes/apps/attack-simulation/ares/app/agents/blue-orchestrator.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/blue-orchestrator.yaml
@@ -36,6 +36,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -44,6 +52,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:

--- a/kubernetes/apps/attack-simulation/ares/app/agents/blue-threat-hunter.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/blue-threat-hunter.yaml
@@ -37,6 +37,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -45,6 +53,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:

--- a/kubernetes/apps/attack-simulation/ares/app/agents/blue-triage.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/blue-triage.yaml
@@ -37,6 +37,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -45,6 +53,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:

--- a/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/cracker.yaml
@@ -29,6 +29,15 @@ spec:
       imagePullSecrets:
         - name: ghcr-auth
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -37,6 +46,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
         - name: agent
           image: ghcr.io/l50/ares-cracker-agent:latest

--- a/kubernetes/apps/attack-simulation/ares/app/agents/lateral-movement.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/lateral-movement.yaml
@@ -37,6 +37,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -45,6 +53,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:

--- a/kubernetes/apps/attack-simulation/ares/app/agents/orchestrator.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/orchestrator.yaml
@@ -34,6 +34,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -42,6 +50,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:

--- a/kubernetes/apps/attack-simulation/ares/app/agents/privesc.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/agents/privesc.yaml
@@ -37,6 +37,14 @@ spec:
                     operator: NotIn
                     values:
                       - k8s7
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - macworker
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -45,6 +53,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/part-of: attack-simulation
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.homelab/laptop
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       hostAliases:
         - ip: "10.1.10.10"
           hostnames:


### PR DESCRIPTION
**Key Changes:**

- Added preferred node affinity for `macworker` role across all attack-simulation agent deployments
- Added toleration for `node.homelab/laptop` taint to allow scheduling on laptop nodes
- Changes apply uniformly to all 9 agent manifests, enabling consistent scheduling behavior on Mac worker nodes

**Changed:**

- Node scheduling configuration for all attack-simulation agents (`acl`, `blue-lateral-analyst`, `blue-orchestrator`, `blue-threat-hunter`, `blue-triage`, `cracker`, `lateral-movement`, `orchestrator`, `privesc`) - added a `preferredDuringSchedulingIgnoredDuringExecution` node affinity rule with weight 100 targeting nodes with `role=macworker`, and a toleration for the `node.homelab/laptop=true:NoSchedule` taint so pods can land on laptop-class nodes when preferred