### PR TITLE
feat: add vector-ares-ingest deployment for ares log ingestion into loki

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ./tempo/ks.yaml
   - ./unpoller/ks.yaml
   - ./vector/ks.yaml
+  - ./vector-ares-ingest/ks.yaml

--- a/kubernetes/apps/observability/vector-ares-ingest/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/vector-ares-ingest/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vector-ares-ingest-aws
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: vector-ares-ingest-aws
+  # The 1Password item must expose these exact field names so they land as env
+  # vars the AWS SDK reads (the Vector pod consumes them via envFrom):
+  #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+  # Populate from the DreadOps ares-logging terragrunt outputs:
+  #   terragrunt output -raw ingestor_access_key_id
+  #   terragrunt output -raw ingestor_secret_access_key
+  dataFrom:
+    - extract:
+        key: "k8s-woe-ares-s3-ingestor"

--- a/kubernetes/apps/observability/vector-ares-ingest/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector-ares-ingest/app/helmrelease.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector-ares-ingest
+  namespace: observability
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: vector
+      version: 0.56.0
+      sourceRef:
+        kind: HelmRepository
+        name: vector
+        namespace: observability
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Aggregator (Deployment); this is a poller — no inbound service needed.
+    role: Stateless-Aggregator
+    replicas: 1
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+    # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the ares-logging ingestor
+    # IAM user (k3s has no IRSA), synced from 1Password by the ExternalSecret.
+    envFrom:
+      - secretRef:
+          name: vector-ares-ingest-aws
+    customConfig:
+      data_dir: /vector-data-dir
+      api:
+        enabled: true
+        address: "0.0.0.0:8686"
+      sources:
+        # Poll the SQS queue fed by S3 ObjectCreated notifications, then read
+        # the gzipped newline-delimited JSON objects the ares-side Vector wrote.
+        ares_s3:
+          type: aws_s3
+          region: us-east-1
+          sqs:
+            queue_url: "https://sqs.us-east-1.amazonaws.com/898493401173/alpha-operator-range-prod-ares-logs-s3-events"
+            poll_secs: 15
+          framing:
+            method: newline_delimited
+          decoding:
+            codec: json
+      sinks:
+        to_loki:
+          type: loki
+          inputs: ["ares_s3"]
+          endpoint: "http://loki-gateway.observability.svc.cluster.local:80"
+          encoding:
+            codec: json
+          # namespace=attack-simulation inherits Loki's 180d red-team retention.
+          # deployment/host/job come from the ares-side shipper's labels.
+          labels:
+            namespace: "attack-simulation"
+            app: "ares"
+            deployment: "{{`{{ deployment }}`}}"
+            environment: "{{`{{ environment }}`}}"
+            host: "{{`{{ host }}`}}"
+            job: "{{`{{ job }}`}}"
+          out_of_order_action: "accept"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/observability/vector-ares-ingest/app/kustomization.yaml
+++ b/kubernetes/apps/observability/vector-ares-ingest/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/vector-ares-ingest/ks.yaml
+++ b/kubernetes/apps/observability/vector-ares-ingest/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vector-ares-ingest
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 30m
+  path: ./kubernetes/apps/observability/vector-ares-ingest/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: observability
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
**Key Changes:**

- Introduces a new Vector aggregator deployment that polls an AWS SQS/S3 pipeline to ingest ares attack-simulation logs into the cluster Loki instance
- AWS credentials for the ares-logging IAM user are securely synced from 1Password via an ExternalSecret rather than hardcoded
- Logs are routed to Loki under the `attack-simulation` namespace with dynamic labels (deployment, environment, host, job) sourced from the ares-side shipper

**Added:**

- Flux Kustomization entrypoint - `ks.yaml` registers the `vector-ares-ingest` app with Flux, targeting the `observability` namespace with a 30m reconcile interval and 5m timeout
- HelmRelease for Vector aggregator - `helmrelease.yaml` deploys Vector in `Stateless-Aggregator` role (1 replica) configured to poll SQS queue `alpha-operator-range-prod-ares-logs-s3-events` every 15 seconds, decode gzipped newline-delimited JSON from S3, and forward events to `loki-gateway` with attack-simulation retention labels; resource limits set to 256Mi memory and 50m CPU
- ExternalSecret for AWS credentials - `externalsecret.yaml` pulls `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the `k8s-woe-ares-s3-ingestor` 1Password item via `ClusterSecretStore`, consumed by the Vector pod via `envFrom`
- App-level kustomization - `app/kustomization.yaml` composes the ExternalSecret and HelmRelease resources
- Observability stack registration - added `./vector-ares-ingest/ks.yaml` to the top-level `observability/kustomization.yaml` so Flux discovers the new app