### PR TITLE
fix: correct traefik helm chart log configuration keys

### DIFF
--- a/kubernetes/apps/networking/ingress-traefik/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/ingress-traefik/app/helmrelease.yaml
@@ -70,13 +70,12 @@ spec:
       dashboard:
         enabled: false
 
-    logs:
-      general:
-        format: json
-        level: DEBUG
-      access:
-        enabled: true
-        format: json
+    log:
+      format: json
+      level: DEBUG
+    accessLog:
+      enabled: true
+      format: json
 
     rbac:
       enabled: true


### PR DESCRIPTION
**Key Changes:**

- Renamed deprecated `logs` configuration keys to the correct `log` and `accessLog` keys as required by the Traefik Helm chart schema
- Flattened the nested `logs.general` structure into a top-level `log` block
- Separated access log configuration into its own top-level `accessLog` block

**Changed:**

- Traefik log configuration structure - Replaced the deprecated nested `logs.general` and `logs.access` keys with the correct top-level `log` and `accessLog` keys in `helmrelease.yaml`, preserving all existing values (`format: json`, `level: DEBUG`, and `enabled: true`)