### PR TITLE
fix: switch vector-ares-ingest from envFrom to explicit env var refs

### DIFF
--- a/kubernetes/apps/observability/vector-ares-ingest/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector-ares-ingest/app/helmrelease.yaml
@@ -30,9 +30,22 @@ spec:
       reloader.stakater.com/auto: "true"
     # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the ares-logging ingestor
     # IAM user (k3s has no IRSA), synced from 1Password by the ExternalSecret.
-    envFrom:
-      - secretRef:
-          name: vector-ares-ingest-aws
+    env:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: vector-ares-ingest-aws
+            key: access_key_id
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: vector-ares-ingest-aws
+            key: secret_access_key
+      - name: AWS_REGION
+        valueFrom:
+          secretKeyRef:
+            name: vector-ares-ingest-aws
+            key: region
     customConfig:
       data_dir: /vector-data-dir
       api:


### PR DESCRIPTION
**Key Changes:**

- Replaced bulk `envFrom` secret reference with individual `env` entries for each AWS credential
- Added explicit key mappings for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`
- Provides finer-grained control over which keys are projected from the secret into the container environment

**Changed:**

- AWS credential injection method - Replaced `envFrom.secretRef` (which mounts all keys from the secret as-is) with individual `env[].valueFrom.secretKeyRef` entries that explicitly map `access_key_id`, `secret_access_key`, and `region` keys from the `vector-ares-ingest-aws` secret to their expected `AWS_*` environment variable names in `helmrelease.yaml`