### PR TITLE
refactor: switch alloy log collection to filesystem-based scraping

### DIFF
--- a/kubernetes/apps/observability/alloy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/alloy/app/helmrelease.yaml
@@ -64,11 +64,23 @@ spec:
               source_labels = ["__meta_kubernetes_pod_node_name"]
               target_label  = "node"
             }
+            rule {
+              action = "replace"
+              source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name", "__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+              separator = "/"
+              replacement = "/var/log/pods/$1_$2_$3/$4/*.log"
+              target_label  = "__path__"
+            }
           }
 
-          // Scrape Kubernetes pod logs
-          loki.source.kubernetes "pods" {
-            targets    = discovery.relabel.pods.output
+          // Match log files on the host
+          local.file_match "pods" {
+            path_targets = discovery.relabel.pods.output
+          }
+
+          // Scrape Kubernetes pod logs directly from filesystem
+          loki.source.file "pods" {
+            targets    = local.file_match.pods.targets
             forward_to = [loki.process.home_automation.receiver]
           }
 
@@ -194,6 +206,9 @@ spec:
         extra:
           - name: alloy-data
             mountPath: /var/lib/alloy
+          - name: varlog
+            mountPath: /var/log
+            readOnly: true
 
     controller:
       type: daemonset
@@ -205,6 +220,10 @@ spec:
             hostPath:
               path: /var/lib/alloy
               type: DirectoryOrCreate
+          - name: varlog
+            hostPath:
+              path: /var/log
+              type: Directory
       extraPorts:
         - name: syslog-udp
           port: 1514


### PR DESCRIPTION
**Key Changes:**

- Replaced Kubernetes API-based pod log scraping with direct filesystem log collection for improved reliability
- Added host `/var/log` volume mount to give Alloy direct access to pod log files on the node
- Introduced a new relabeling rule to construct the log file path from pod metadata

**Added:**

- Host log volume - Mounted the node's `/var/log` directory into the Alloy daemonset pods as a read-only volume (`varlog`), exposing pod log files on the filesystem for direct collection

**Changed:**

- Log collection method - Replaced `loki.source.kubernetes` with `local.file_match` and `loki.source.file` components to read pod logs directly from the host filesystem (`/var/log/pods/...`) rather than through the Kubernetes API, reducing API server load and improving collection stability
- Pod metadata relabeling - Added a new relabel rule that constructs the `__path__` target label by combining namespace, pod name, pod UID, and container name into the standard pod log path format (`/var/log/pods/$namespace_$pod_$uid/$container/*.log`)