### PR TITLE
fix: increase adguard-home memory resource limits

### DIFF
--- a/kubernetes/apps/networking/adguard-home/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/adguard-home/app/helmrelease.yaml
@@ -74,10 +74,10 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 64Mi
+                memory: 256Mi
               limits:
                 cpu: 250m
-                memory: 128Mi
+                memory: 512Mi
 
     service:
       app:


### PR DESCRIPTION
**Key Changes:**

- Doubled memory requests and quadrupled memory limits for AdGuard Home to prevent OOM issues
- Updated both request and limit thresholds to provide adequate headroom for DNS workloads

**Changed:**

- AdGuard Home memory allocation - Increased memory requests from `64Mi` to `256Mi` and limits from `128Mi` to `512Mi` in `helmrelease.yaml` to better accommodate actual runtime memory usage