### PR TITLE
feat: add attack simulation observability dashboards and enhance tempo metrics

### DIFF
--- a/kubernetes/apps/attack-simulation/ares/app/ares-config.yaml
+++ b/kubernetes/apps/attack-simulation/ares/app/ares-config.yaml
@@ -23,6 +23,15 @@ data:
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo.observability.svc.cluster.local:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_SERVICE_NAMESPACE: "ares"
+  OTEL_METRICS_EXPORTER: "none"
+  OTEL_LOGS_EXPORTER: "none"
+  OTEL_RESOURCE_ATTRIBUTES: >-
+    service.namespace=attack-simulation,
+    deployment.environment=woe,
+    attack.team=red,
+    attack.framework=mitre-attack,
+    attack.platform=windows,
+    attack.domain=enterprise
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -60,6 +69,15 @@ data:
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo.observability.svc.cluster.local:4317"
   OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   OTEL_SERVICE_NAMESPACE: "ares-blue"
+  OTEL_METRICS_EXPORTER: "none"
+  OTEL_LOGS_EXPORTER: "none"
+  TEMPO_URL: "http://tempo.observability.svc.cluster.local:3200"
+  OTEL_RESOURCE_ATTRIBUTES: >-
+    service.namespace=attack-simulation,
+    deployment.environment=woe,
+    attack.team=blue,
+    attack.role=defender,
+    investigation.framework=mitre-defend
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/apps/observability/grafana/app/dashboards/ares-agents-dashboard.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/ares-agents-dashboard.yaml
@@ -117,8 +117,8 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "sum by (pod) (rate({namespace=\"attack-simulation\", pod=~\"ares-.*\"}[1m]))",
-              "legendFormat": "{{pod}}",
+              "expr": "sum by (job) (rate({namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"}[1m]))",
+              "legendFormat": "{{job}}",
               "refId": "A"
             }
           ],
@@ -161,7 +161,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "{namespace=\"attack-simulation\", pod=~\"ares-(orchestrator|recon-agent|credential-access-agent|acl-agent|privesc-agent|lateral-movement-agent|coercion-agent).*\"}",
+              "expr": "{namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|acl.log|privesc.log|lateral.log|coercion.log|cracker.log\"} | json | line_format \"{{ .message }}\" | decolorize",
               "refId": "A"
             }
           ],
@@ -175,7 +175,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "{namespace=\"attack-simulation\", pod=~\"ares-blue-.*\"}",
+              "expr": "{namespace=\"attack-simulation\", job=~\"blue.*\"} | json | line_format \"{{ .message }}\" | decolorize",
               "refId": "A"
             }
           ],
@@ -207,7 +207,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "{namespace=\"attack-simulation\", pod=~\"ares-.*\"} |~ \"(?i)error|panic|fatal|warn\"",
+              "expr": "{namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"} |~ \"(?i)error|panic|fatal|warn\" | json | line_format \"{{ .message }}\" | decolorize",
               "refId": "A"
             }
           ],

--- a/kubernetes/apps/observability/grafana/app/dashboards/attack-operation-summary-dashboard.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/attack-operation-summary-dashboard.yaml
@@ -1,0 +1,1989 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: attack-operation-summary-dashboard
+  namespace: observability
+  labels:
+    grafana_dashboard: "1"
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+  annotations:
+    grafana_folder: "Attack Simulation"
+    dashboard-version: "2.0.0"
+    last-modified: "2026-05-07"
+data:
+  attack-operation-summary.json: |
+    {
+      "uid": "attack-operation-summary",
+      "title": "Attack Operation Summary - Deep Dive",
+      "description": "Deep dive analysis of individual attack operations. Select an operation ID to view complete attack path, techniques used, hosts accessed, and credentials discovered.",
+      "tags": [
+        "attack-simulation",
+        "tempo",
+        "traces",
+        "operation-report",
+        "mitre-attack"
+      ],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "links": [
+        {
+          "title": "Overview",
+          "type": "link",
+          "url": "/d/attack-simulation-overview",
+          "icon": "apps",
+          "tooltip": "Back to overview dashboard"
+        },
+        {
+          "title": "Attack Graph",
+          "type": "link",
+          "url": "/d/attack-graph?var-operation_id=$operation_id",
+          "icon": "sitemap",
+          "tooltip": "View network traversal graph"
+        },
+        {
+          "title": "Red Team Logs",
+          "type": "link",
+          "url": "/d/red-team-agent-logs",
+          "icon": "gf-logs",
+          "tooltip": "View agent logs"
+        },
+        {
+          "title": "Blue Team Detection",
+          "type": "link",
+          "url": "/d/blue-team-detection",
+          "icon": "shield",
+          "tooltip": "View security detections"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "environment",
+            "type": "custom",
+            "current": {
+              "selected": true,
+              "text": "staging",
+              "value": "staging"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "label": "Environment",
+            "query": "dev,staging",
+            "options": [
+              {
+                "selected": false,
+                "text": "dev",
+                "value": "dev"
+              },
+              {
+                "selected": true,
+                "text": "staging",
+                "value": "staging"
+              }
+            ]
+          },
+          {
+            "name": "operation_id",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "query": "label_values(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", attack_operation_id!=\"\"}, attack_operation_id)",
+            "refresh": 2,
+            "includeAll": false,
+            "multi": false,
+            "label": "Operation ID",
+            "sort": 2
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "OPERATION OVERVIEW",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": 2,
+          "title": "Operation Duration",
+          "type": "stat",
+          "description": "Total duration from first to last span in this operation",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "max(max_over_time(traces_spanmetrics_latency_sum{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\"}[$__range])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 300
+                  },
+                  {
+                    "color": "red",
+                    "value": 3600
+                  }
+                ]
+              },
+              "unit": "s",
+              "displayName": "Duration"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          }
+        },
+        {
+          "id": 3,
+          "title": "Total Techniques",
+          "type": "stat",
+          "description": "Count of unique MITRE techniques used in this operation",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (mitre_technique_id) (traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", mitre_technique_id!=\"\"})) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Techniques"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 6,
+            "y": 1
+          }
+        },
+        {
+          "id": 4,
+          "title": "Hosts Accessed",
+          "type": "stat",
+          "description": "Count of unique hosts/IPs accessed during this operation",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (destination_address) (traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", destination_address!=\"\"})) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 15
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Hosts"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 10,
+            "y": 1
+          }
+        },
+        {
+          "id": 5,
+          "title": "Credentials Used",
+          "type": "stat",
+          "description": "Count of unique user credentials used/discovered",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (user_name) (traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", user_name!=\"\"})) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Credentials"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 14,
+            "y": 1
+          }
+        },
+        {
+          "id": 6,
+          "title": "Success Rate",
+          "type": "stat",
+          "description": "Percentage of successful operations (OK status)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "(sum(increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", status_code=\"STATUS_CODE_OK\"}[$__range])) / sum(increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\"}[$__range])) * 100) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 50
+                  },
+                  {
+                    "color": "green",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent",
+              "displayName": "Success",
+              "max": 100,
+              "min": 0
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          }
+        },
+        {
+          "id": 10,
+          "title": "OPERATION TIMELINE",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          }
+        },
+        {
+          "id": 11,
+          "title": "Event Timeline",
+          "type": "timeseries",
+          "description": "Timeline of attack events, stacked by MITRE technique and colored by attack phase",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (mitre_technique_id, attack_phase) (rate(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", mitre_technique_id!=\"\"}[1m])) * 60",
+              "refId": "A",
+              "legendFormat": "{{attack_phase}}: {{mitre_technique_id}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "bars",
+                "lineInterpolation": "linear",
+                "barAlignment": 0,
+                "lineWidth": 1,
+                "fillOpacity": 80,
+                "gradientMode": "hue",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "ops/min"
+            }
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "sum"
+              ]
+            }
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          }
+        },
+        {
+          "id": 12,
+          "title": "Operation Traces",
+          "type": "table",
+          "description": "All traces for this operation. Click trace ID to view in Explore.",
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "targets": [
+            {
+              "queryType": "traceqlSearch",
+              "query": "{ resource.service.namespace = \"attack-simulation\" && span.attack_operation_id = \"$operation_id\" }",
+              "refId": "A",
+              "limit": 100,
+              "tableType": "traces"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "traceID"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 280
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "View Trace",
+                        "url": "/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22queryType%22:%22traceqlSearch%22,%22query%22:%22${__value.raw}%22%7D%5D%7D",
+                        "targetBlank": true
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "traceDuration"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ms"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 120
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          }
+        },
+        {
+          "id": 20,
+          "title": "ATTACK PATH",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          }
+        },
+        {
+          "id": 21,
+          "title": "Attack Phases",
+          "type": "piechart",
+          "description": "Distribution of attack operations by phase",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (attack_phase) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", attack_phase!=\"\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "{{attack_phase}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "reconnaissance"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "credential-access"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "privilege-escalation"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "lateral-movement"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "persistence"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "exfiltration"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 27
+          }
+        },
+        {
+          "id": 22,
+          "title": "MITRE Techniques",
+          "type": "bargauge",
+          "description": "Techniques used in this operation, sorted by count",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "topk(15, sum by (mitre_technique_id, mitre_technique_name) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", mitre_technique_id!=\"\"}[$__range])))",
+              "refId": "A",
+              "legendFormat": "{{mitre_technique_id}}: {{mitre_technique_name}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 15
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "unit": "short"
+            }
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true,
+            "minVizHeight": 10
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 8,
+            "y": 27
+          }
+        },
+        {
+          "id": 23,
+          "title": "Technique Details",
+          "type": "table",
+          "description": "Full details of all techniques used: tactic, technique ID, name, and execution count",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (mitre_tactic, mitre_technique_id, mitre_technique_name) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", mitre_technique_id!=\"\"}[$__range]))",
+              "refId": "A",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "mitre_tactic"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Tactic"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 140
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "reconnaissance": {
+                            "text": "Reconnaissance",
+                            "color": "blue"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "credential-access": {
+                            "text": "Credential Access",
+                            "color": "yellow"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "privilege-escalation": {
+                            "text": "Privilege Escalation",
+                            "color": "orange"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "lateral-movement": {
+                            "text": "Lateral Movement",
+                            "color": "red"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "persistence": {
+                            "text": "Persistence",
+                            "color": "purple"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "defense-evasion": {
+                            "text": "Defense Evasion",
+                            "color": "dark-green"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "exfiltration": {
+                            "text": "Exfiltration",
+                            "color": "dark-red"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "mitre_technique_id"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Technique ID"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "mitre_technique_name"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Technique Name"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 300
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Count"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 80
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 5
+                        },
+                        {
+                          "color": "red",
+                          "value": 15
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "mitre_tactic": 0,
+                  "mitre_technique_id": 1,
+                  "mitre_technique_name": 2,
+                  "Value": 3
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "field": "Value",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          }
+        },
+        {
+          "id": 30,
+          "title": "DISCOVERED ASSETS",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          }
+        },
+        {
+          "id": 31,
+          "title": "Hosts Accessed",
+          "type": "table",
+          "description": "All hosts accessed during this operation with type, domain, and access count",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (destination_address, attack_target_host, attack_target_type, attack_target_domain) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", destination_address!=\"\"}[$__range]))",
+              "refId": "A",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "destination_address"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "IP Address"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "attack_target_host"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Hostname"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 200
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "attack_target_type"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Type"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "domain_controller": {
+                            "text": "Domain Controller",
+                            "color": "red"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "server": {
+                            "text": "Server",
+                            "color": "yellow"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "workstation": {
+                            "text": "Workstation",
+                            "color": "green"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "": {
+                            "text": "Unknown",
+                            "color": "gray"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "attack_target_domain"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Domain"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Access Count"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 5
+                        },
+                        {
+                          "color": "red",
+                          "value": 15
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "destination_address": 0,
+                  "attack_target_host": 1,
+                  "attack_target_domain": 2,
+                  "attack_target_type": 3,
+                  "Value": 4
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "field": "Value",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          }
+        },
+        {
+          "id": 32,
+          "title": "Credentials Discovered",
+          "type": "table",
+          "description": "User credentials discovered or used during this operation",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (user_name, attack_target_domain) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", user_name!=\"\"}[$__range]))",
+              "refId": "A",
+              "format": "table",
+              "instant": true
+            },
+            {
+              "expr": "count by (user_name) (count by (user_name, mitre_technique_id) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", user_name!=\"\", mitre_technique_id!=\"\"}[$__range]) > 0))",
+              "refId": "B",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "user_name"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "User"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "attack_target_domain"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Domain"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 180
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #A"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Usage Count"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #B"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Techniques"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 80
+                  }
+                ]
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "merge"
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 2": true
+                },
+                "indexByName": {
+                  "user_name": 0,
+                  "attack_target_domain": 1,
+                  "Value #A": 2,
+                  "Value #B": 3
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "field": "Value #A",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          }
+        },
+        {
+          "id": 40,
+          "title": "TOOLS & INVESTIGATION",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 57
+          }
+        },
+        {
+          "id": 41,
+          "title": "Tools Used",
+          "type": "bargauge",
+          "description": "Attack tools used during this operation",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (attack_tool_name) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=\"$operation_id\", attack_tool_name!=\"\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "{{attack_tool_name}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 15
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "unit": "short"
+            }
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true,
+            "minVizHeight": 10
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 58
+          }
+        },
+        {
+          "id": 42,
+          "title": "Explore Links",
+          "type": "text",
+          "description": "Quick links to explore this operation in detail",
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 58
+          },
+          "options": {
+            "mode": "markdown",
+            "content": "## Quick Links\n\n- [Operation traces in Tempo](/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22queryType%22:%22traceqlSearch%22,%22query%22:%22%7B%20span.attack_operation_id%20%3D%20%5C%22$operation_id%5C%22%20%7D%22%7D%5D%7D)\n- [Service map](/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22queryType%22:%22serviceMap%22%7D%5D%7D)\n\nSee the TraceQL Query Examples panel for more."
+          }
+        },
+        {
+          "id": 50,
+          "title": "ATTACK PHASE ANALYSIS",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 68
+          }
+        },
+        {
+          "id": 51,
+          "title": "Attack Phase Duration (p95)",
+          "type": "bargauge",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (attack_phase, le) (rate(traces_spanmetrics_latency_bucket{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_phase!=\"\"}[15m])))",
+              "refId": "A",
+              "legendFormat": "{{attack_phase}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 60
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "unit": "s"
+            }
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 69
+          }
+        },
+        {
+          "id": 60,
+          "title": "ATTACK PATHS",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 77
+          }
+        },
+        {
+          "id": 61,
+          "title": "Lateral Movement Paths",
+          "type": "table",
+          "description": "Lateral movement with credentials used. Tracks attacker movement through the network.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (destination_address, destination_ip, host_name, user_name, attack_target_type) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id=~\"$operation_id\", mitre_tactic=\"lateral-movement\", destination_address=~\"[a-zA-Z0-9].*\\\\..*\", destination_address!~\".* .*|.*\\\\$\"}[$__range])) > 0",
+              "refId": "A",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "destination_address"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "FQDN"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "destination_ip"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "IP"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "host_name"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Hostname"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "user_name"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Credential Used"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "attack_target_type"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Target Type"
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "domain_controller": {
+                            "text": "DC",
+                            "color": "red"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "server": {
+                            "text": "Server",
+                            "color": "yellow"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "workstation": {
+                            "text": "WS",
+                            "color": "green"
+                          }
+                        }
+                      },
+                      {
+                        "type": "value",
+                        "options": {
+                          "": {
+                            "text": "Unknown",
+                            "color": "gray"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Moves"
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "blue",
+                          "value": null
+                        },
+                        {
+                          "color": "purple",
+                          "value": 3
+                        },
+                        {
+                          "color": "red",
+                          "value": 10
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "destination_address": 0,
+                  "destination_ip": 1,
+                  "host_name": 2,
+                  "attack_target_type": 3,
+                  "user_name": 4,
+                  "Value": 5
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "field": "Value",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 78
+          }
+        },
+        {
+          "id": 70,
+          "title": "RED VS BLUE CORRELATION",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 88
+          }
+        },
+        {
+          "id": 71,
+          "title": "Red Team Activity vs Blue Team Detection",
+          "type": "timeseries",
+          "description": "Compare red team attack operations against blue team investigation traces",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_team=\"red\"}[5m])) * 60",
+              "refId": "A",
+              "legendFormat": "Red Team Operations"
+            },
+            {
+              "expr": "sum(rate(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_team=\"blue\"}[5m])) * 60",
+              "refId": "B",
+              "legendFormat": "Blue Team Investigations"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "fillOpacity": 30
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "ops/min"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Red Team Operations"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Blue Team Investigations"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 89
+          }
+        },
+        {
+          "id": 72,
+          "title": "Detection Timing Gap",
+          "type": "timeseries",
+          "description": "Time between red team attack initiation and blue team detection (lower is better)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "avg(rate(traces_spanmetrics_latency_sum{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_team=\"blue\", investigation_type!=\"\"}[5m]) / rate(traces_spanmetrics_latency_count{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_team=\"blue\", investigation_type!=\"\"}[5m])) or vector(0)",
+              "refId": "A",
+              "legendFormat": "Avg Investigation Duration"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "fillOpacity": 20
+              },
+              "color": {
+                "fixedColor": "purple",
+                "mode": "fixed"
+              },
+              "unit": "s"
+            }
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "showLegend": true
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 89
+          }
+        },
+        {
+          "id": 80,
+          "title": "TRACE SEARCH",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 97
+          }
+        },
+        {
+          "id": 81,
+          "title": "Attack Traces Search",
+          "type": "table",
+          "description": "Search for attack traces using TraceQL. Click a trace ID to view details in Explore.",
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "targets": [
+            {
+              "queryType": "traceqlSearch",
+              "query": "{ resource.service.namespace = \"attack-simulation\" && resource.deployment.environment =~ \"$environment\" }",
+              "refId": "A",
+              "limit": 50,
+              "tableType": "traces"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "traceID"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 280
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "View Trace",
+                        "url": "/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22queryType%22:%22traceqlSearch%22,%22query%22:%22${__value.raw}%22%7D%5D%7D",
+                        "targetBlank": true
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "traceDuration"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ms"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 120
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 98
+          }
+        },
+        {
+          "id": 90,
+          "title": "INVESTIGATION GUIDANCE",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 108
+          }
+        },
+        {
+          "id": 91,
+          "title": "TraceQL Query Examples",
+          "type": "text",
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 109
+          },
+          "options": {
+            "mode": "markdown",
+            "content": "## TraceQL Examples\n\n```\n{ span.attack_operation_id = \"$operation_id\" }\n{ span.attack_operation_id = \"$operation_id\" && status = error }\n{ span.mitre_tactic = \"lateral-movement\" }\n{ span.mitre_technique_id = \"T1003\" }\n{ span.destination.address = \"dc01.north.sevenkingdoms.local\" }\n```"
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/grafana/app/dashboards/attack-simulation-overview-dashboard.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/attack-simulation-overview-dashboard.yaml
@@ -1,0 +1,1552 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: attack-simulation-overview-dashboard
+  namespace: observability
+  labels:
+    grafana_dashboard: "1"
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+  annotations:
+    grafana_folder: "Attack Simulation"
+data:
+  attack-simulation-overview.json: |
+    {
+      "uid": "attack-simulation-overview",
+      "title": "Attack Simulation - Overview",
+      "description": "Attack simulation overview. Span-metrics panels populate from local woe ares operations via Tempo; log panels read range logs ingested by vector-ares-ingest (job=<role>.log, deployment=alpha-operator-range-*). destination_address / attack_target_type panels stay empty unless those Tempo dimensions are promoted.",
+      "tags": [
+        "attack-simulation",
+        "overview",
+        "health",
+        "ares",
+        "mitre-attack"
+      ],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "links": [
+        {
+          "title": "Operation Deep Dive",
+          "type": "link",
+          "url": "/d/attack-operation-summary",
+          "icon": "search",
+          "tooltip": "Deep dive into individual attack operations"
+        },
+        {
+          "title": "Attack Graph",
+          "type": "link",
+          "url": "/d/attack-graph",
+          "icon": "sitemap",
+          "tooltip": "Network traversal visualization"
+        },
+        {
+          "title": "Red Team Logs",
+          "type": "link",
+          "url": "/d/red-team-agent-logs",
+          "icon": "gf-logs",
+          "tooltip": "Ares agent logs and debugging"
+        },
+        {
+          "title": "Blue Team Detection",
+          "type": "link",
+          "url": "/d/blue-team-detection",
+          "icon": "shield",
+          "tooltip": "Windows & Linux security log detections"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "environment",
+            "type": "custom",
+            "current": {
+              "text": "All",
+              "value": ".*",
+              "selected": true
+            },
+            "hide": 0,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": false,
+            "label": "Environment",
+            "query": "All : .*,woe : woe",
+            "options": [
+              {
+                "text": "All",
+                "value": ".*",
+                "selected": true
+              },
+              {
+                "text": "woe",
+                "value": "woe",
+                "selected": false
+              }
+            ]
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "ATTACK SIMULATION STATUS",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": 2,
+          "title": "Active Agents",
+          "type": "stat",
+          "description": "Number of attack agents currently generating traces",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (service) (rate(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", service=~\"ares-.*\"}[5m]) > 0)) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "green",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Active Agents"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "textMode": "value"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          }
+        },
+        {
+          "id": 3,
+          "title": "Operations (1h)",
+          "type": "stat",
+          "description": "Unique attack operations in the last hour",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (attack_operation_id) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id!=\"\"}[1h]) > 0)) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Operations"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          }
+        },
+        {
+          "id": 4,
+          "title": "Hosts Targeted (1h)",
+          "type": "stat",
+          "description": "Unique hosts accessed in attack operations",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (destination_address) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", destination_address!=\"\", destination_address!~\"<.*>|unknown|AUTO_ENUM\"}[1h]) > 0)) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 15
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Hosts"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 1
+          }
+        },
+        {
+          "id": 5,
+          "title": "Techniques Used (1h)",
+          "type": "stat",
+          "description": "Unique MITRE techniques executed",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (mitre_technique_id) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", mitre_technique_id!=\"\"}[1h]) > 0)) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 25
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Techniques"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 1
+          }
+        },
+        {
+          "id": 6,
+          "title": "Success Rate",
+          "type": "stat",
+          "description": "Percentage of successful attack operations",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "(sum(increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", status_code=\"STATUS_CODE_OK\"}[1h])) / sum(increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\"}[1h])) * 100) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 50
+                  },
+                  {
+                    "color": "green",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent",
+              "displayName": "Success",
+              "max": 100,
+              "min": 0
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 1
+          }
+        },
+        {
+          "id": 7,
+          "title": "Errors (5m)",
+          "type": "stat",
+          "description": "Error count in agent logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"} |~ \"(?i)ERROR\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Errors"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 1
+          }
+        },
+        {
+          "id": 10,
+          "title": "ATTACK ACTIVITY",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          }
+        },
+        {
+          "id": 11,
+          "title": "Attack Activity by MITRE Tactic",
+          "type": "timeseries",
+          "description": "Attack operations over time, grouped by MITRE ATT&CK tactic",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (mitre_tactic) (rate(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", mitre_tactic!=\"\"}[5m])) * 60",
+              "refId": "A",
+              "legendFormat": "{{mitre_tactic}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "bars",
+                "lineInterpolation": "linear",
+                "barAlignment": 0,
+                "lineWidth": 1,
+                "fillOpacity": 80,
+                "gradientMode": "hue",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "ops/min"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "reconnaissance"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "credential-access"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "privilege-escalation"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "lateral-movement"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "persistence"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "defense-evasion"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "exfiltration"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "sum",
+                "lastNotNull"
+              ]
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 0,
+            "y": 6
+          }
+        },
+        {
+          "id": 12,
+          "title": "Tactic Distribution",
+          "type": "piechart",
+          "description": "Distribution of attack operations by MITRE tactic",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (mitre_tactic) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", mitre_tactic!=\"\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "{{mitre_tactic}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "reconnaissance"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "credential-access"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "privilege-escalation"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "lateral-movement"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "persistence"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "defense-evasion"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "exfiltration"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 6
+          }
+        },
+        {
+          "id": 20,
+          "title": "AGENT HEALTH",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 14
+          }
+        },
+        {
+          "id": 21,
+          "title": "Agent Status",
+          "type": "table",
+          "description": "Health status of all attack simulation agents",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (service) (rate(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", service=~\"ares-.*\"}[5m])) * 60",
+              "refId": "A",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "{{service}}"
+            },
+            {
+              "expr": "sum by (service) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", service=~\"ares-.*\", status_code=\"STATUS_CODE_ERROR\"}[1h]))",
+              "refId": "B",
+              "format": "table",
+              "instant": true
+            },
+            {
+              "expr": "count by (service) (count by (service, mitre_technique_id) (traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", service=~\"ares-.*\", mitre_technique_id!=\"\"}))",
+              "refId": "C",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "service"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Agent"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 250
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #A"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Ops/min"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.1
+                        },
+                        {
+                          "color": "green",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #B"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Errors (1h)"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 1
+                        },
+                        {
+                          "color": "red",
+                          "value": 10
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #C"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Techniques"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  }
+                ]
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "merge"
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "service": 0,
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "Value #C": 3
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "field": "Value #A",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          }
+        },
+        {
+          "id": 22,
+          "title": "Agent Activity Over Time",
+          "type": "timeseries",
+          "description": "Trace volume by agent service",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (service) (rate(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", service=~\"ares-.*\"}[5m])) * 60",
+              "refId": "A",
+              "legendFormat": "{{service}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "ops/min"
+            }
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          }
+        },
+        {
+          "id": 30,
+          "title": "RECENT OPERATIONS",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 23
+          }
+        },
+        {
+          "id": 31,
+          "title": "Recent Attack Operations",
+          "type": "table",
+          "description": "Most recent attack operations with key metrics. Click operation ID for deep dive.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "topk(20, sum by (attack_operation_id) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id!=\"\"}[$__range])))",
+              "refId": "A",
+              "format": "table",
+              "instant": true
+            },
+            {
+              "expr": "count by (attack_operation_id) (count by (attack_operation_id, mitre_technique_id) (traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id!=\"\", mitre_technique_id!=\"\"}))",
+              "refId": "B",
+              "format": "table",
+              "instant": true
+            },
+            {
+              "expr": "count by (attack_operation_id) (count by (attack_operation_id, destination_address) (traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_operation_id!=\"\", destination_address!=\"\", destination_address!~\"<.*>|unknown\"}))",
+              "refId": "C",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "links": [
+                {
+                  "title": "View Operation Details",
+                  "url": "/d/attack-operation-summary?var-operation_id=${__data.fields.attack_operation_id}&from=${__from}&to=${__to}",
+                  "targetBlank": true
+                }
+              ]
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "attack_operation_id"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Operation ID"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 220
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #A"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Total Spans"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #B"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Techniques"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #C"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Hosts"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 100
+                  }
+                ]
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "merge"
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 2": true
+                },
+                "indexByName": {
+                  "attack_operation_id": 0,
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "Value #C": 3
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "field": "Value #A",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "countRows": true
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          }
+        },
+        {
+          "id": 32,
+          "title": "Target Types",
+          "type": "bargauge",
+          "description": "Hosts accessed by target type",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum by (attack_target_type) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", attack_target_type!=\"\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "{{attack_target_type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 50
+                  },
+                  {
+                    "color": "red",
+                    "value": 200
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "domain_controller"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "server"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "workstation"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true,
+            "minVizHeight": 10
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 24
+          }
+        },
+        {
+          "id": 33,
+          "title": "Top Techniques",
+          "type": "bargauge",
+          "description": "Most frequently used MITRE techniques",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "topk(8, sum by (mitre_technique_id) (increase(traces_spanmetrics_calls_total{service_namespace=~\"attack-simulation|ares\", deployment_environment=~\"$environment\", mitre_technique_id!=\"\"}[$__range])))",
+              "refId": "A",
+              "legendFormat": "{{mitre_technique_id}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 100
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "unit": "short"
+            }
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true,
+            "minVizHeight": 10
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 24
+          }
+        },
+        {
+          "id": 40,
+          "title": "ERRORS & DETECTIONS",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          }
+        },
+        {
+          "id": 41,
+          "title": "Recent Errors",
+          "type": "logs",
+          "description": "Recent error logs from all attack agents",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"} |~ \"(?i)(ERROR|exception|failed)\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 100
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 100,
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          }
+        },
+        {
+          "id": 42,
+          "title": "Blue Team Detections (5m)",
+          "type": "stat",
+          "description": "Security log detections triggered",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({deployment=~\"alpha-operator-range.*\"} |~ \"(?i)(exploit|payload|shell|reverse|meterpreter|mimikatz|bloodhound|rubeus|impacket|secretsdump)\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Detections"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 33
+          }
+        },
+        {
+          "id": 43,
+          "title": "DCSync Attempts (5m)",
+          "type": "stat",
+          "description": "DCSync attack detection events",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({deployment=~\"alpha-operator-range.*\"} | json | event_id=\"4662\" |~ \"(?i)(1131f6aa|1131f6ad|89e95b76|DS-Replication)\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "DCSync Events"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 33
+          }
+        },
+        {
+          "id": 44,
+          "title": "Log Volume by Agent",
+          "type": "timeseries",
+          "description": "Log output rate by agent service",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate({namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"}[1m])) * 60",
+              "refId": "A",
+              "legendFormat": "{{app}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "bars",
+                "lineWidth": 1,
+                "fillOpacity": 80,
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "logs/min"
+            }
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/grafana/app/dashboards/red-team-agent-logs-dashboard.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/red-team-agent-logs-dashboard.yaml
@@ -1,0 +1,1740 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: red-team-agent-logs-dashboard
+  namespace: observability
+  labels:
+    grafana_dashboard: "1"
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+  annotations:
+    grafana_folder: "Attack Simulation"
+data:
+  red-team-agent-logs.json: |
+    {
+      "uid": "red-team-agent-logs",
+      "title": "Red Team Agent Logs",
+      "description": "Red team agent logs ingested into woe's Loki from the external alpha-operator-range via vector-ares-ingest. Agents distinguished by the 'job' label (<role>.log); log bodies unwrapped from the JSON envelope.",
+      "tags": [
+        "attack-simulation",
+        "loki",
+        "logs",
+        "red-team",
+        "ares"
+      ],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 300,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "title": "Overview",
+          "type": "link",
+          "url": "/d/attack-simulation-overview",
+          "icon": "apps",
+          "tooltip": "Back to overview dashboard"
+        },
+        {
+          "title": "Operation Deep Dive",
+          "type": "link",
+          "url": "/d/attack-operation-summary",
+          "icon": "search",
+          "tooltip": "Analyze specific operations"
+        },
+        {
+          "title": "Attack Graph",
+          "type": "link",
+          "url": "/d/attack-graph",
+          "icon": "sitemap",
+          "tooltip": "View network traversal graph"
+        },
+        {
+          "title": "Blue Team Detection",
+          "type": "link",
+          "url": "/d/blue-team-detection",
+          "icon": "shield",
+          "tooltip": "View security detections"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "agent",
+            "type": "custom",
+            "current": {
+              "text": "All Red Team",
+              "value": "orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log",
+              "selected": true
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "label": "Agent",
+            "query": "All Red Team : orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log,Orchestrator : orchestrator.log,Recon : recon.log,Credential Access : credential_access.log,Lateral Movement : lateral.log,Privilege Escalation : privesc.log,Coercion : coercion.log,Cracker : cracker.log,ACL : acl.log",
+            "options": [
+              {
+                "text": "All Red Team",
+                "value": "orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log",
+                "selected": true
+              },
+              {
+                "text": "Orchestrator",
+                "value": "orchestrator.log",
+                "selected": false
+              },
+              {
+                "text": "Recon",
+                "value": "recon.log",
+                "selected": false
+              },
+              {
+                "text": "Credential Access",
+                "value": "credential_access.log",
+                "selected": false
+              },
+              {
+                "text": "Lateral Movement",
+                "value": "lateral.log",
+                "selected": false
+              },
+              {
+                "text": "Privilege Escalation",
+                "value": "privesc.log",
+                "selected": false
+              },
+              {
+                "text": "Coercion",
+                "value": "coercion.log",
+                "selected": false
+              },
+              {
+                "text": "Cracker",
+                "value": "cracker.log",
+                "selected": false
+              },
+              {
+                "text": "ACL",
+                "value": "acl.log",
+                "selected": false
+              }
+            ]
+          },
+          {
+            "name": "level",
+            "type": "custom",
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": ".*"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "label": "Log Level",
+            "query": ".* : All : .*,INFO|Info|info : INFO : INFO|Info|info,DEBUG|Debug|debug : DEBUG : DEBUG|Debug|debug,WARN|Warn|warn|WARNING : WARN : WARN|Warn|warn|WARNING,ERROR|Error|error : ERROR : ERROR|Error|error",
+            "options": [
+              {
+                "selected": true,
+                "text": "All",
+                "value": ".*"
+              },
+              {
+                "selected": false,
+                "text": "INFO",
+                "value": "INFO|Info|info"
+              },
+              {
+                "selected": false,
+                "text": "DEBUG",
+                "value": "DEBUG|Debug|debug"
+              },
+              {
+                "selected": false,
+                "text": "WARN",
+                "value": "WARN|Warn|warn|WARNING"
+              },
+              {
+                "selected": false,
+                "text": "ERROR",
+                "value": "ERROR|Error|error"
+              }
+            ]
+          },
+          {
+            "name": "search",
+            "type": "textbox",
+            "current": {
+              "selected": false,
+              "text": "",
+              "value": ""
+            },
+            "hide": 0,
+            "label": "Search",
+            "options": []
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "OVERVIEW",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": 2,
+          "title": "Total Logs (5m)",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"}[5m]))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Log Lines"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          }
+        },
+        {
+          "id": 3,
+          "title": "Errors (5m)",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)ERROR\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Errors"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          }
+        },
+        {
+          "id": 4,
+          "title": "Warnings (5m)",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)WARN\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "orange",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Warnings"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 1
+          }
+        },
+        {
+          "id": 5,
+          "title": "Active Agents",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (job) (count_over_time({namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"}[5m])))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Active Agents"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 1
+          }
+        },
+        {
+          "id": 6,
+          "title": "Operations Detected (5m)",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "count(count by (job) (count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"op-\\\\d{8}-\\\\d{6}\"[5m]))) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "purple",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Operations"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 1
+          }
+        },
+        {
+          "id": 7,
+          "title": "Task Executions (5m)",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)(executing|completed|task|dispatch)\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Tasks"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 1
+          }
+        },
+        {
+          "id": 8,
+          "title": "LOOT & RUNTIME",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          }
+        },
+        {
+          "id": 80,
+          "title": "Credentials Broadcast",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Credentials broadcast to agents (publish_credential calls)",
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"publish_credential|broadcast_credential|credential.*added|new credential\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Credentials"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 6
+          }
+        },
+        {
+          "id": 81,
+          "title": "Hashes Cracked",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Hash cracking successes",
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"cracked|report_cracked_credential|hashcat.*success\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Cracked"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 6
+          }
+        },
+        {
+          "id": 82,
+          "title": "Hosts Targeted",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Hosts enumerated or targeted in attacks",
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"all_hosts|host.*added|target.*host|destination\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Hosts"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 6
+          }
+        },
+        {
+          "id": 83,
+          "title": "Ops Completed",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Operations completed successfully (with duration)",
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"completed successfully.*duration\"[24h])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Completed"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 6
+          }
+        },
+        {
+          "id": 84,
+          "title": "Vulns Exploited",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Vulnerabilities successfully exploited",
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"exploited_vulnerabilities|vuln.*exploited|exploit.*success\"[5m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 3
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "Exploited"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 6
+          }
+        },
+        {
+          "id": 85,
+          "title": "Domain Admin",
+          "type": "stat",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Domain Admin achieved events",
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"DOMAIN ADMIN|has_domain_admin|domain.*admin.*achieved\"[24h])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short",
+              "displayName": "DA"
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 6
+          }
+        },
+        {
+          "id": 86,
+          "title": "Operation Runtime Log",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Operation start, completion, and duration messages",
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"orchestrator.log\"} |~ \"(completed successfully|started_at|Operation.*running|duration)\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 100
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 100,
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          }
+        },
+        {
+          "id": 87,
+          "title": "Loot Summary",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "description": "Loot discovery events: credentials, hashes, hosts, domains, shares, weaknesses, domain admin achievements",
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(DOMAIN ADMIN ACHIEVED|GOLDEN TICKET OBTAINED|Hash added:|Credential added:|Domains \\\\(|Hosts \\\\(|Users \\\\(|Credentials \\\\(|Hashes \\\\(|Shares \\\\(|Weaknesses \\\\(|has_domain_admin|domain_admin_path|publish_credential|broadcast_credential|new credential|\\\\[hash\\\\]|\\\\[cred\\\\]|\\\\[user\\\\]|\\\\[host\\\\]|\\\\[domain\\\\])\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 500
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": false,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending",
+            "prettifyLogMessage": false
+          },
+          "maxDataPoints": 500,
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          }
+        },
+        {
+          "id": 10,
+          "title": "Log Volume by Agent",
+          "type": "timeseries",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate({namespace=\"attack-simulation\", job=~\"$agent\"}[1m])) * 60",
+              "refId": "A",
+              "legendFormat": "{{app}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "bars",
+                "lineInterpolation": "linear",
+                "barAlignment": 0,
+                "lineWidth": 1,
+                "fillOpacity": 80,
+                "gradientMode": "hue",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "logs/min"
+            }
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "sum",
+                "mean"
+              ]
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          }
+        },
+        {
+          "id": 11,
+          "title": "Log Level Distribution",
+          "type": "timeseries",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)ERROR\"[1m])) * 60",
+              "refId": "A",
+              "legendFormat": "ERROR"
+            },
+            {
+              "expr": "sum(rate({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)WARN\"[1m])) * 60",
+              "refId": "B",
+              "legendFormat": "WARN"
+            },
+            {
+              "expr": "sum(rate({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)INFO\" !~ \"(?i)(ERROR|WARN)\"[1m])) * 60",
+              "refId": "C",
+              "legendFormat": "INFO"
+            },
+            {
+              "expr": "sum(rate({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)DEBUG\"[1m])) * 60",
+              "refId": "D",
+              "legendFormat": "DEBUG"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "fillOpacity": 30
+              },
+              "unit": "logs/min"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ERROR"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "WARN"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "INFO"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "DEBUG"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          }
+        },
+        {
+          "id": 20,
+          "title": "ORCHESTRATOR",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 30
+          }
+        },
+        {
+          "id": 21,
+          "title": "Red Orchestrator Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"orchestrator.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 500
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 500,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 31
+          }
+        },
+        {
+          "id": 30,
+          "title": "ATTACK WORKERS",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 41
+          }
+        },
+        {
+          "id": 31,
+          "title": "Recon Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"recon.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 200
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 200,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          }
+        },
+        {
+          "id": 32,
+          "title": "Credential Access Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"credential_access.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 200
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 200,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          }
+        },
+        {
+          "id": 33,
+          "title": "Lateral Movement Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"lateral.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 200
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 200,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          }
+        },
+        {
+          "id": 34,
+          "title": "Privilege Escalation Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"privesc.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 200
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 200,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          }
+        },
+        {
+          "id": 35,
+          "title": "Coercion Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"coercion.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 200
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 200,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 58
+          }
+        },
+        {
+          "id": 36,
+          "title": "Cracker Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"cracker.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 200
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 200,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 58
+          }
+        },
+        {
+          "id": 37,
+          "title": "ACL Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=\"acl.log\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 200
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 200,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 66
+          }
+        },
+        {
+          "id": 40,
+          "title": "ERROR TRACKING",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 74
+          }
+        },
+        {
+          "id": 41,
+          "title": "Recent Errors",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)ERROR\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 500
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 500,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 75
+          }
+        },
+        {
+          "id": 42,
+          "title": "Errors by Agent",
+          "type": "piechart",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (count_over_time({namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"} |~ \"(?i)ERROR\"[$__range]))",
+              "refId": "A",
+              "legendFormat": "{{app}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              }
+            }
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 85
+          }
+        },
+        {
+          "id": 43,
+          "title": "Error Timeline",
+          "type": "timeseries",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate({namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"} |~ \"(?i)ERROR\"[1m])) * 60",
+              "refId": "A",
+              "legendFormat": "{{app}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "bars",
+                "lineWidth": 1,
+                "fillOpacity": 80,
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "errors/min"
+            }
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 85
+          }
+        },
+        {
+          "id": 50,
+          "title": "REDIS & CONNECTIVITY",
+          "type": "row",
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 93
+          },
+          "panels": [
+            {
+              "id": 51,
+              "title": "Redis Connection Events",
+              "type": "logs",
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "targets": [
+                {
+                  "expr": "{namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)(redis|connection|reconnect|disconnect)\" | json | line_format \"{{ .message }}\" | decolorize",
+                  "refId": "A",
+                  "maxLines": 300
+                }
+              ],
+              "options": {
+                "showTime": true,
+                "showLabels": true,
+                "wrapLogMessage": true,
+                "enableLogDetails": true,
+                "dedupStrategy": "none",
+                "sortOrder": "Descending"
+              },
+              "maxDataPoints": 300,
+              "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 94
+              }
+            },
+            {
+              "id": 52,
+              "title": "Connection Errors",
+              "type": "stat",
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "targets": [
+                {
+                  "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)(connection.*error|connection.*closed|connection.*refused)\"[$__range]))",
+                  "refId": "A"
+                }
+              ],
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 5
+                      },
+                      {
+                        "color": "red",
+                        "value": 20
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "displayName": "Connection Errors"
+                }
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center"
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 8,
+                "x": 0,
+                "y": 104
+              }
+            },
+            {
+              "id": 53,
+              "title": "Reconnection Attempts",
+              "type": "stat",
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "targets": [
+                {
+                  "expr": "sum(count_over_time({namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"(?i)reconnect\"[$__range]))",
+                  "refId": "A"
+                }
+              ],
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 10
+                      },
+                      {
+                        "color": "orange",
+                        "value": 50
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "displayName": "Reconnects"
+                }
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center"
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 8,
+                "x": 8,
+                "y": 104
+              }
+            }
+          ]
+        },
+        {
+          "id": 60,
+          "title": "FULL LOG SEARCH",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 94
+          }
+        },
+        {
+          "id": 61,
+          "title": "All Red Team Agent Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"attack-simulation\", job=~\"$agent\"} |~ \"$level\" |~ \"$search\" | json | line_format \"{{ .message }}\" | decolorize",
+              "refId": "A",
+              "maxLines": 1000
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "maxDataPoints": 1000,
+          "gridPos": {
+            "h": 15,
+            "w": 24,
+            "x": 0,
+            "y": 95
+          }
+        },
+        {
+          "id": 70,
+          "title": "ORCHESTRATOR INFRA",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 110
+          }
+        },
+        {
+          "id": 71,
+          "title": "Orchestrator Pod Restarts",
+          "description": "Container restarts for the orchestrator pod over time. Folded in from the deprecated rust-orchestrator-metrics dashboard.",
+          "type": "timeseries",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "count_over_time({namespace=\"attack-simulation\", job=\"orchestrator.log\"} |= \"starting\" [5m])",
+              "legendFormat": "Orchestrator Starts",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 50,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "stacking": {
+                  "mode": "none"
+                }
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 111
+          }
+        },
+        {
+          "id": 72,
+          "title": "Recovery Events",
+          "description": "Recovery manager events: state reconstruction after orchestrator restart. Folded in from the deprecated rust-orchestrator-metrics dashboard.",
+          "type": "timeseries",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "count_over_time({namespace=\"attack-simulation\", job=\"orchestrator.log\"} |~ \"(?i)recovery|reconstructing|recovered\" [5m])",
+              "legendFormat": "Recovery Events",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "stacking": {
+                  "mode": "none"
+                }
+              },
+              "unit": "s"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 111
+          }
+        },
+        {
+          "id": 73,
+          "title": "Worker Agent Restart Rate",
+          "description": "Container restarts across all red team worker agents. Folded in from the deprecated rust-orchestrator-metrics dashboard.",
+          "type": "timeseries",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (count_over_time({namespace=\"attack-simulation\", job=~\"orchestrator.log|recon.log|credential_access.log|lateral.log|privesc.log|coercion.log|cracker.log|acl.log\"} |~ \"(?i)starting|restarting|ares worker exited\" [5m]))",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 50,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 119
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -18,3 +18,7 @@ resources:
   - ./dashboards/troy-backup-dashboard.yaml
   - ./dashboards/adguard-iphone-dns-dashboard.yaml
   - ./dashboards/cluster-recovery-dashboard.yaml
+  - ./dashboards/attack-operation-summary-dashboard.yaml
+  - ./dashboards/red-team-agent-logs-dashboard.yaml
+  - ./dashboards/attack-simulation-overview-dashboard.yaml
+  - ./dashboards/ares-agents-dashboard.yaml

--- a/kubernetes/apps/observability/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/tempo/app/helmrelease.yaml
@@ -87,9 +87,30 @@ spec:
             dimensions:
               - service.namespace
               - deployment.environment
+              - target.environment
+              - mitre.tactic
+              - mitre.technique.id
+              - mitre.technique.name
+              - attack_team
+              - attack_phase
+              - attack_tool_name
+              - attack_tool_category
+              - tool.status
+              - attack_operation_id
+              - destination.address
+              - user.name
+              - investigation_type
+              - investigation_phase
+          local_blocks:
+            flush_to_storage: false
+            complete_block_timeout: 30m
           service_graphs:
             wait: 10s
             max_items: 10000
+            dimensions:
+              - attack_team
+              - attack_phase
+              - mitre.tactic
         storage:
           path: /var/tempo/metrics
           remote_write:
@@ -107,8 +128,12 @@ spec:
             processors:
               - service-graphs
               - span-metrics
+              - local-blocks
 
     replicas: 1
+
+    nodeSelector:
+      kubernetes.io/hostname: k8s9
 
     persistence:
       enabled: true


### PR DESCRIPTION
**Key Changes:**

- Introduced three new Grafana dashboards providing comprehensive attack simulation visibility: overview, operation deep dive, and red team agent logs
- Extended Tempo span-metrics dimensions to capture MITRE ATT&CK attributes, attack team/phase/tool metadata, and investigation context
- Migrated Loki log queries from pod-label selectors to job-label selectors to align with vector-ares-ingest log ingestion patterns
- Enriched OTEL resource attributes for both red and blue team ares agents with team, framework, platform, and domain context

**Added:**

- Attack Simulation Overview dashboard - new `attack-simulation-overview-dashboard.yaml` providing high-level stats (active agents, operations, hosts, techniques, success rate, errors), MITRE tactic timeseries and distribution, agent health table, recent operations table, and blue team detection counters backed by Prometheus span-metrics and Loki
- Attack Operation Summary dashboard - new `attack-operation-summary-dashboard.yaml` enabling per-operation deep dive with operation duration, technique count, hosts accessed, credentials used, success rate stats, event timeline, full Tempo trace table, MITRE technique breakdown, lateral movement path table, red vs blue correlation timeseries, and TraceQL search panels
- Red Team Agent Logs dashboard - new `red-team-agent-logs-dashboard.yaml` with per-agent log panels (orchestrator, recon, credential access, lateral movement, privilege escalation, coercion, cracker, ACL), loot summary panel, error tracking with pie chart and timeline, orchestrator infra restart tracking, and a full log search panel with agent/level/search template variables
- Dashboard kustomization entries - registered all three new dashboards plus `ares-agents-dashboard.yaml` in `grafana/app/kustomization.yaml`

**Changed:**

- Tempo span-metrics dimensions - extended `helmrelease.yaml` to promote MITRE ATT&CK attributes (`mitre.tactic`, `mitre.technique.id`, `mitre.technique.name`), attack context (`attack_team`, `attack_phase`, `attack_tool_name`, `attack_tool_category`, `attack_operation_id`), network context (`destination.address`, `user.name`), and blue team investigation fields (`investigation_type`, `investigation_phase`) as Prometheus label dimensions; also added `local_blocks` processor and service-graph dimensions
- Tempo node affinity - pinned Tempo deployment to `k8s9` via `nodeSelector` to ensure consistent storage locality with the enabled persistence volume
- Ares agent OTEL config - added `OTEL_METRICS_EXPORTER: none` and `OTEL_LOGS_EXPORTER: none` to suppress unwanted exporters, and added `OTEL_RESOURCE_ATTRIBUTES` to both red and blue team ConfigMaps with team, framework, platform/domain, and environment attributes; blue team config also gains `TEMPO_URL` for direct trace querying
- Ares agents dashboard log queries - updated all Loki expressions in `ares-agents-dashboard.yaml` to use `job=~"<role>.log"` selectors instead of `pod=~"ares-.*"` pod selectors, and added `| json | line_format "{{ .message }}" | decolorize` pipeline stages to unwrap JSON-enveloped log bodies