### PR TITLE
fix: increase traefik read timeout to prevent large upload failures

### DIFF
--- a/kubernetes/apps/networking/ingress-traefik/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/ingress-traefik/app/helmrelease.yaml
@@ -176,3 +176,8 @@ spec:
         expose:
           default: true
         exposedPort: 443
+        transport:
+          respondingTimeouts:
+            # Traefik v3 defaults readTimeout to 60s, which aborts
+            # large uploads (e.g. Immich videos) mid-request.
+            readTimeout: 30m


### PR DESCRIPTION
**Key Changes:**

- Extended the default read timeout from 60s to 30m to prevent mid-request aborts for large file uploads
- Addresses a Traefik v3 behavior change where the default `readTimeout` was reduced, breaking uploads of large files such as Immich videos

**Changed:**

- Read timeout configuration - Added `transport.respondingTimeouts.readTimeout: 30m` to the Traefik HelmRelease to override the Traefik v3 default of 60s, which was insufficient for large uploads (e.g. Immich videos) - `kubernetes/apps/networking/ingress-traefik/app/helmrelease.yaml`