### PR TITLE
chore: adjust alloy resource requests and limits

### DIFF
--- a/kubernetes/apps/observability/alloy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/alloy/app/helmrelease.yaml
@@ -202,10 +202,10 @@ spec:
           }
       resources:
         requests:
-          cpu: 1388m
-          memory: 259Mi
+          cpu: 300m
+          memory: 512Mi
         limits:
-          memory: 400Mi
+          memory: 768Mi
       storagePath: /var/lib/alloy
       mounts:
         extra:


### PR DESCRIPTION
**Key Changes:**

- Reduced CPU request while increasing memory allocations for the Alloy deployment
- Rebalanced resource requests and limits to better match actual workload needs

**Changed:**

- Alloy resource configuration - Lowered CPU request from 1388m to 300m and raised memory request from 259Mi to 512Mi, along with increasing the memory limit from 400Mi to 768Mi in `kubernetes/apps/observability/alloy/app/helmrelease.yaml` to right-size resource allocation for the workload