### PR TITLE
fix: increase adguard-home memory resources

### DIFF
--- a/kubernetes/apps/networking/adguard-home/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/adguard-home/app/helmrelease.yaml
@@ -74,10 +74,10 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 256Mi
+                memory: 512Mi
               limits:
                 cpu: 250m
-                memory: 512Mi
+                memory: 768Mi
 
     service:
       app:


### PR DESCRIPTION
**Key Changes:**

- Raised memory requests and limits for the AdGuard Home deployment to provide additional headroom

**Changed:**

- AdGuard Home resource allocation - Increased memory request from 256Mi to 512Mi and memory limit from 512Mi to 768Mi in `kubernetes/apps/networking/adguard-home/app/helmrelease.yaml` to prevent resource pressure