### PR TITLE
feat: deploy frigate NVR with RK3588 hardware acceleration

### DIFF
--- a/kubernetes/apps/home-automation/frigate/README.md
+++ b/kubernetes/apps/home-automation/frigate/README.md
@@ -1,0 +1,162 @@
+# Frigate
+
+NVR for the six wired cameras on VLAN 40. Pulls RTSP directly from the cameras;
+Synology Surveillance Station is not in the path.
+
+Runs on k8s9 (`node-role.kubernetes.io/storage=true`) — the only node with the
+Rockchip BSP kernel (`6.1.0-1025-rockchip`) and the RK3588 media devices.
+
+## Verified on hardware
+
+| Check | Result |
+| --- | --- |
+| `h264_rkmpp` / `hevc_rkmpp` in image ffmpeg | present (ffmpeg 7.0) |
+| RKNN runtime | `/usr/lib/librknnrt.so`, `rknnlite` imports |
+| SoC autodetect | `rk3588` (requires privileged — see below) |
+| Live 4K HEVC decode via `hevc_rkmpp` | 240 frames @ realtime |
+| k8s9 → VLAN 40 RTSP | reachable, no firewall change needed |
+| MetalLB `192.168.20.18` TCP+UDP on 8555 | assigned |
+
+## Camera facts (measured, not assumed)
+
+| Camera | IP | Main stream | Sub stream |
+| --- | --- | --- | --- |
+| front_left | .200 | HEVC 3840x2160 | HEVC 640x480 |
+| front_right | .201 | assumed same as .200 | assumed same |
+| back_left | .202 | assumed same as .200 | assumed same |
+| back_right | .203 | HEVC 3840x2160 (via SS bridge) | not reachable |
+| living_room | .204 | H.264 2560x1440 | **absent (404)** |
+| garage | .205 | assumed same as .204 | assumed absent |
+
+Hikvisions are HEVC (`preset-rk-h265`); Amcrests are H.264 (`preset-rk-h264`).
+Setting one global hwaccel breaks half the fleet.
+
+## Storage layout
+
+| Path | Backing | Why |
+| --- | --- | --- |
+| `/config` | `local-path` on k8s9 NVMe | SQLite; corrupts over NFS |
+| `/media/frigate` | `nfs-client` → Synology | recordings + snapshots |
+| `/tmp/cache` | emptyDir on NVMe | segment staging before NFS move |
+| `/dev/shm` | 512Mi tmpfs | 64MB default too small; Frigate wants ≥146MB |
+
+## Pre-flight
+
+### 1. Store the Surveillance Station RTSP credential
+
+Back Right (192.168.40.203) is pulled through Surveillance Station's RTSP
+restream rather than directly, because no password in the vault authenticates
+to that camera — both `Back Right Camera` items
+(`2bxl4dk7dzwf63lkkhfcpbets4`, `kajbbi33gkyhczluodyzmzidoa`) return HTTP 401,
+while the other five return 200. SS still holds working credentials for it.
+
+Retrieve the restream credential (stable across calls; re-check if SS is
+reconfigured):
+
+```sh
+SID=$(curl -sk -G https://192.168.20.210:5001/webapi/entry.cgi \
+  --data-urlencode api=SYNO.API.Auth --data-urlencode version=6 \
+  --data-urlencode method=login --data-urlencode account=<dsm-user> \
+  --data-urlencode passwd=<dsm-pass> --data-urlencode session=SurveillanceStation \
+  --data-urlencode format=sid | jq -r .data.sid)
+curl -sk -G https://192.168.20.210:5001/webapi/entry.cgi \
+  --data-urlencode api=SYNO.SurveillanceStation.Camera --data-urlencode version=9 \
+  --data-urlencode method=GetLiveViewPath --data-urlencode idList=12 \
+  --data-urlencode _sid=$SID | jq -r '.data[].rtspPath'
+```
+
+Store the password portion in 1Password vault `automation` as item
+`synology-surveillance-rtsp`, field `password`.
+
+This bridge has real costs: it keeps Surveillance Station in the dependency
+chain, routes 4K video through the NAS, and exposes only the main stream — so
+Back Right decodes 3840x2160 for detection while its siblings decode 640x480.
+The clean fix is a physical factory reset of that camera, after which it moves
+to a direct pull like the others and gains a substream.
+
+Camera IDs in Surveillance Station: front_left=9, front_right=10, back_left=11,
+back_right=12, living_room=13, garage=14.
+
+### 2. Raise the detect-stream resolution
+
+Face recognition runs on the **detect** stream only. The Hikvision substreams
+are 640x480, which yields roughly a 13-pixel-wide face at 10 ft — far below the
+~80 px ArcFace needs. Raise each Hikvision substream to 1280x720 or 1920x1080 in
+the camera web UI, then update `detect.width` / `detect.height` to match.
+
+Object detection ("a person is there") works fine at 640x480. Only face
+recognition is gated by this.
+
+### 3. Enable the Amcrest substreams
+
+`subtype=1` returns 404 on 192.168.40.204 — the substream is disabled. Until
+it is enabled, those cameras decode their full 2560x1440 main stream for
+detection, which is far more expensive than necessary. Enable the substream in
+the Amcrest UI, add a `*_sub` go2rtc entry, and point the `detect` role at it.
+
+### 4. Exclude Frigate recordings from HyperBackup
+
+`/volume1` is a single 26.2 TB pool shared with the Immich library and its
+pg_dump backups, which HyperBackup replicates to Backblaze B2.
+
+DSM → HyperBackup → the B2 task → Edit source → deselect
+`k8s/home-automation-frigate-media-*`.
+
+Note the cameras are 4K/1440p, not 4MP: continuous recording across all six is
+closer to 475 GB/day than the 250 GB/day originally estimated. The configured
+retention (3d continuous / 14d motion / 30d alerts) keeps steady state near
+1.5 TB.
+
+### 5. Cap Frigate's share of the volume
+
+`nfs-subdir-external-provisioner` ignores the `2Ti` PVC request — it only
+creates a directory, so Frigate sees all free space on `/volume1`.
+
+DSM → Control Panel → Shared Folder → the share backing `/volume1/k8s` →
+Edit → Quota.
+
+### 6. Verify the model block
+
+`model.path: deci-fp16-yolonas_s` matches the plugin's
+`^deci-fp16-yolonas_[sml]$` preset pattern, but the full download-and-convert
+path has not been exercised end to end. Watch the first startup for conversion
+errors. Note DeciAI's YOLO-NAS weights are non-commercial-use only.
+
+## Why privileged
+
+`frigate/detectors/plugins/rknn.py` calls `get_soc()`, which reads
+`/proc/device-tree/compatible` — a symlink to `/sys/firmware/devicetree/base`.
+containerd masks `/sys/firmware` with a read-only tmpfs, and that mask is
+applied *after* volume mounts, so a hostPath cannot win. There is no config
+option to supply the SoC directly.
+
+A device plugin was tested and does solve device access
+(`open(O_RDWR)` succeeds non-privileged on all five device nodes), but it does
+not defeat the `/sys/firmware` mask, so it cannot replace privileged on its own.
+
+Given Frigate parses untrusted video from network cameras, compensating
+controls matter: keep VLAN 40 isolated, keep the cameras off the internet, and
+pin the image tag rather than tracking `stable-rk`.
+
+## Access
+
+| Route | Address |
+| --- | --- |
+| Web UI | `https://frigate.techvomit.xyz` (Frigate's own auth on 8971) |
+| RTSP restream | `rtsp://192.168.20.18:8554/<camera>` |
+| WebRTC live view | `192.168.20.18:8555` TCP+UDP |
+
+DNS comes from external-dns. The zone is publicly resolvable but points at
+RFC1918 addresses, so remote access requires the UDM Pro VPN.
+
+## Known trade-offs
+
+- `config.yml` is mounted read-only from a ConfigMap, so git stays the source of
+  truth. This disables the 0.17 camera wizard and the live zone/mask editor. To
+  draw zones: temporarily remove the `config-file` mount, draw them in the UI,
+  copy the coordinates back into the ConfigMap, restore the mount.
+- No zones are defined yet. Alert quality depends almost entirely on them.
+- `strategy: Recreate` is required. Two pods against one SQLite database
+  corrupts it.
+- `archiveOnDelete: "true"` on `nfs-client` means deleting the media PVC renames
+  the directory rather than freeing the space.

--- a/kubernetes/apps/home-automation/frigate/README.md
+++ b/kubernetes/apps/home-automation/frigate/README.md
@@ -3,7 +3,7 @@
 NVR for the six wired cameras on VLAN 40. Pulls RTSP directly from the cameras;
 Synology Surveillance Station is not in the path.
 
-Runs on k8s9 (`node-role.kubernetes.io/storage=true`) — the only node with the
+Runs on k8s9 (`node-role.kubernetes.io/storage=true`), the only node with the
 Rockchip BSP kernel (`6.1.0-1025-rockchip`) and the RK3588 media devices.
 
 ## Verified on hardware
@@ -46,7 +46,7 @@ Setting one global hwaccel breaks half the fleet.
 
 Back Right (192.168.40.203) is pulled through Surveillance Station's RTSP
 restream rather than directly, because no password in the vault authenticates
-to that camera — both `Back Right Camera` items
+to that camera: both `Back Right Camera` items
 (`2bxl4dk7dzwf63lkkhfcpbets4`, `kajbbi33gkyhczluodyzmzidoa`) return HTTP 401,
 while the other five return 200. SS still holds working credentials for it.
 
@@ -69,7 +69,7 @@ Store the password portion in 1Password vault `automation` as item
 `synology-surveillance-rtsp`, field `password`.
 
 This bridge has real costs: it keeps Surveillance Station in the dependency
-chain, routes 4K video through the NAS, and exposes only the main stream — so
+chain, routes 4K video through the NAS, and exposes only the main stream, so
 Back Right decodes 3840x2160 for detection while its siblings decode 640x480.
 The clean fix is a physical factory reset of that camera, after which it moves
 to a direct pull like the others and gains a substream.
@@ -80,7 +80,7 @@ back_right=12, living_room=13, garage=14.
 ### 2. Raise the detect-stream resolution
 
 Face recognition runs on the **detect** stream only. The Hikvision substreams
-are 640x480, which yields roughly a 13-pixel-wide face at 10 ft — far below the
+are 640x480, which yields roughly a 13-pixel-wide face at 10 ft, far below the
 ~80 px ArcFace needs. Raise each Hikvision substream to 1280x720 or 1920x1080 in
 the camera web UI, then update `detect.width` / `detect.height` to match.
 
@@ -89,7 +89,7 @@ recognition is gated by this.
 
 ### 3. Enable the Amcrest substreams
 
-`subtype=1` returns 404 on 192.168.40.204 — the substream is disabled. Until
+`subtype=1` returns 404 on 192.168.40.204: the substream is disabled. Until
 it is enabled, those cameras decode their full 2560x1440 main stream for
 detection, which is far more expensive than necessary. Enable the substream in
 the Amcrest UI, add a `*_sub` go2rtc entry, and point the `detect` role at it.

--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -1,0 +1,204 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frigate-config
+  namespace: home-automation
+data:
+  config.yml: |-
+    mqtt:
+      enabled: true
+      host: mosquitto.home-automation.svc.cluster.local
+      port: 1883
+      user: "{FRIGATE_MQTT_USER}"
+      password: "{FRIGATE_MQTT_PASSWORD}"
+      topic_prefix: frigate
+      client_id: frigate
+
+    detectors:
+      rknn:
+        type: rknn
+        num_cores: 3
+
+    model:
+      path: deci-fp16-yolonas_s
+      model_type: yolonas
+      width: 320
+      height: 320
+      input_pixel_format: bgr
+      input_tensor: nhwc
+
+    objects:
+      track:
+        - person
+        - car
+        - dog
+
+    face_recognition:
+      enabled: true
+      model_size: large
+      unknown_score: 0.8
+      recognition_threshold: 0.9
+      min_faces: 2
+      save_attempts: 200
+      blur_confidence_filter: true
+
+    semantic_search:
+      enabled: false
+
+    record:
+      enabled: true
+      continuous:
+        days: 3
+      motion:
+        days: 14
+      alerts:
+        retain:
+          days: 30
+      detections:
+        retain:
+          days: 14
+
+    snapshots:
+      enabled: true
+      timestamp: false
+      bounding_box: true
+      retain:
+        default: 30
+
+    review:
+      alerts:
+        labels:
+          - person
+      detections:
+        labels:
+          - car
+          - dog
+
+    go2rtc:
+      webrtc:
+        candidates:
+          - 192.168.20.18:8555
+          - stun:8555
+      streams:
+        front_left:
+          - rtsp://admin:{FRIGATE_FRONT_LEFT_PASSWORD}@192.168.40.200:554/Streaming/Channels/101
+        front_left_sub:
+          - rtsp://admin:{FRIGATE_FRONT_LEFT_PASSWORD}@192.168.40.200:554/Streaming/Channels/102
+        front_right:
+          - rtsp://admin:{FRIGATE_FRONT_RIGHT_PASSWORD}@192.168.40.201:554/Streaming/Channels/101
+        front_right_sub:
+          - rtsp://admin:{FRIGATE_FRONT_RIGHT_PASSWORD}@192.168.40.201:554/Streaming/Channels/102
+        back_left:
+          - rtsp://admin:{FRIGATE_BACK_LEFT_PASSWORD}@192.168.40.202:554/Streaming/Channels/101
+        back_left_sub:
+          - rtsp://admin:{FRIGATE_BACK_LEFT_PASSWORD}@192.168.40.202:554/Streaming/Channels/102
+        back_right:
+          - rtsp://syno:{FRIGATE_SYNO_RTSP_PASSWORD}@192.168.20.210:554/Sms=12.unicast
+        living_room:
+          - rtsp://admin:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.40.204:554/cam/realmonitor?channel=1&subtype=0
+        garage:
+          - rtsp://admin:{FRIGATE_GARAGE_PASSWORD}@192.168.40.205:554/cam/realmonitor?channel=1&subtype=0
+
+    cameras:
+      front_left:
+        detect:
+          enabled: true
+          width: 640
+          height: 480
+          fps: 5
+        ffmpeg:
+          hwaccel_args: preset-rk-h265
+          inputs:
+            - path: rtsp://127.0.0.1:8554/front_left
+              input_args: preset-rtsp-restream
+              roles:
+                - record
+            - path: rtsp://127.0.0.1:8554/front_left_sub
+              input_args: preset-rtsp-restream
+              roles:
+                - detect
+
+      front_right:
+        detect:
+          enabled: true
+          width: 640
+          height: 480
+          fps: 5
+        ffmpeg:
+          hwaccel_args: preset-rk-h265
+          inputs:
+            - path: rtsp://127.0.0.1:8554/front_right
+              input_args: preset-rtsp-restream
+              roles:
+                - record
+            - path: rtsp://127.0.0.1:8554/front_right_sub
+              input_args: preset-rtsp-restream
+              roles:
+                - detect
+
+      back_left:
+        detect:
+          enabled: true
+          width: 640
+          height: 480
+          fps: 5
+        ffmpeg:
+          hwaccel_args: preset-rk-h265
+          inputs:
+            - path: rtsp://127.0.0.1:8554/back_left
+              input_args: preset-rtsp-restream
+              roles:
+                - record
+            - path: rtsp://127.0.0.1:8554/back_left_sub
+              input_args: preset-rtsp-restream
+              roles:
+                - detect
+
+      back_right:
+        detect:
+          enabled: true
+          width: 3840
+          height: 2160
+          fps: 5
+        ffmpeg:
+          hwaccel_args: preset-rk-h265
+          inputs:
+            - path: rtsp://127.0.0.1:8554/back_right
+              input_args: preset-rtsp-restream
+              roles:
+                - record
+                - detect
+
+      living_room:
+        detect:
+          enabled: true
+          width: 2560
+          height: 1440
+          fps: 5
+        ffmpeg:
+          hwaccel_args: preset-rk-h264
+          inputs:
+            - path: rtsp://127.0.0.1:8554/living_room
+              input_args: preset-rtsp-restream
+              roles:
+                - record
+                - detect
+
+      garage:
+        detect:
+          enabled: true
+          width: 2560
+          height: 1440
+          fps: 5
+        ffmpeg:
+          hwaccel_args: preset-rk-h264
+          inputs:
+            - path: rtsp://127.0.0.1:8554/garage
+              input_args: preset-rtsp-restream
+              roles:
+                - record
+                - detect
+
+    version: 0.17

--- a/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: frigate-secret
+  namespace: home-automation
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: frigate-secret
+  data:
+    - secretKey: FRIGATE_FRONT_LEFT_PASSWORD
+      remoteRef:
+        key: Front Left Camera - Synology Credentials
+        property: password
+    - secretKey: FRIGATE_FRONT_RIGHT_PASSWORD
+      remoteRef:
+        key: Front Right Camera - Synology Credentials
+        property: password
+    - secretKey: FRIGATE_BACK_LEFT_PASSWORD
+      remoteRef:
+        key: Back Left Camera
+        property: password
+    - secretKey: FRIGATE_SYNO_RTSP_PASSWORD
+      remoteRef:
+        key: synology-surveillance-rtsp
+        property: password
+    - secretKey: FRIGATE_LIVING_ROOM_PASSWORD
+      remoteRef:
+        key: Living Room Camera
+        property: password
+    - secretKey: FRIGATE_GARAGE_PASSWORD
+      remoteRef:
+        key: Garage Camera
+        property: password
+    - secretKey: FRIGATE_MQTT_USER
+      remoteRef:
+        key: mosquitto
+        property: username
+    - secretKey: FRIGATE_MQTT_PASSWORD
+      remoteRef:
+        key: mosquitto
+        property: password

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -1,0 +1,196 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: frigate
+  namespace: home-automation
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: frigate
+  install:
+    timeout: 15m
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    timeout: 15m
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      frigate:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/blakeblackshear/frigate
+              tag: 0.17.2-rk
+            env:
+              TZ: "America/Denver"
+              LIBVA_DRIVER_NAME: rockchip
+            envFrom:
+              - secretRef:
+                  name: frigate-secret
+            ports:
+              - name: http
+                containerPort: 5000
+                protocol: TCP
+              - name: auth
+                containerPort: 8971
+                protocol: TCP
+              - name: rtsp
+                containerPort: 8554
+                protocol: TCP
+              - name: webrtc
+                containerPort: 8555
+                protocol: TCP
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: 5000
+                  initialDelaySeconds: 120
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: 5000
+                  initialDelaySeconds: 60
+                  periodSeconds: 15
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: 5000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: "1"
+                memory: 4Gi
+              limits:
+                memory: 12Gi
+            securityContext:
+              privileged: true
+        pod:
+          automountServiceAccountToken: false
+          nodeSelector:
+            node-role.kubernetes.io/storage: "true"
+    service:
+      app:
+        controller: frigate
+        ports:
+          http:
+            port: 8971
+      stream:
+        controller: frigate
+        type: LoadBalancer
+        loadBalancerIP: 192.168.20.18
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: frigate-stream.techvomit.xyz
+        ports:
+          rtsp:
+            port: 8554
+            protocol: TCP
+          webrtc-tcp:
+            port: 8555
+            protocol: TCP
+          webrtc-udp:
+            port: 8555
+            protocol: UDP
+    ingress:
+      app:
+        className: ingress-traefik
+        hosts:
+          - host: &host frigate.techvomit.xyz
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: techvomit-xyz-production-tls
+    persistence:
+      config:
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: local-path
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        globalMounts:
+          - path: /config
+      config-file:
+        type: configMap
+        name: frigate-config
+        advancedMounts:
+          frigate:
+            app:
+              - path: /config/config.yml
+                subPath: config.yml
+                readOnly: true
+      media:
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: nfs-client
+        accessMode: ReadWriteOnce
+        size: 2Ti
+        globalMounts:
+          - path: /media/frigate
+      cache:
+        type: emptyDir
+        sizeLimit: 8Gi
+        globalMounts:
+          - path: /tmp/cache
+      dshm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 512Mi
+        globalMounts:
+          - path: /dev/shm
+      dev-dri:
+        type: hostPath
+        hostPath: /dev/dri
+        hostPathType: Directory
+        globalMounts:
+          - path: /dev/dri
+      dev-mpp-service:
+        type: hostPath
+        hostPath: /dev/mpp_service
+        hostPathType: CharDevice
+        globalMounts:
+          - path: /dev/mpp_service
+      dev-rga:
+        type: hostPath
+        hostPath: /dev/rga
+        hostPathType: CharDevice
+        globalMounts:
+          - path: /dev/rga
+      dev-dma-heap:
+        type: hostPath
+        hostPath: /dev/dma_heap
+        hostPathType: Directory
+        globalMounts:
+          - path: /dev/dma_heap

--- a/kubernetes/apps/home-automation/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+  - pairs:
+      app.kubernetes.io/name: frigate
+      app.kubernetes.io/instance: frigate
+namespace: home-automation
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/home-automation/frigate/app/ocirepository.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: frigate
+  namespace: home-automation
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home-automation/frigate/ks.yaml
+++ b/kubernetes/apps/home-automation/frigate/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app frigate
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: mosquitto
+    - name: onepassword
+  interval: 30m
+  path: ./kubernetes/apps/home-automation/frigate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: *namespace
+  retryInterval: 1m
+  targetNamespace: home-automation
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./frigate/ks.yaml
   - ./home-assistant/ks.yaml
   - ./mosquitto/ks.yaml
   - ./music-assistant/ks.yaml


### PR DESCRIPTION
**Key Changes:**

- Added a complete Frigate deployment for six wired VLAN 40 cameras with RKNN object detection and RK3588 hardware-accelerated video decoding, pinned to the storage node (k8s9)
- Configured per-camera ffmpeg presets (HEVC for Hikvisions, H.264 for Amcrests) with go2rtc restreaming, face recognition, and tiered recording retention
- Wired camera and MQTT credentials through 1Password via ExternalSecret, and exposed WebUI, RTSP, and WebRTC access via ingress and a MetalLB LoadBalancer
- Documented hardware verification, privileged-mode rationale, storage layout, and pre-flight setup steps in a comprehensive README

**Added:**

- Frigate HelmRelease using the bjw-s app-template chart - Deploys image `0.17.2-rk` with privileged security context, Recreate strategy (to protect the SQLite config from concurrent-pod corruption), liveness/readiness/startup probes, and hostPath mounts for `/dev/dri`, `/dev/mpp_service`, `/dev/rga`, and `/dev/dma_heap` to reach RK3588 media devices - `app/helmrelease.yaml`
- Frigate configuration ConfigMap - Defines the RKNN detector, YOLO-NAS model block, face recognition, tiered recording (3d continuous / 14d motion / 30d alerts), and per-camera detect/record roles with correct hwaccel presets; mounted read-only so git remains the source of truth - `app/configmap.yaml`
- ExternalSecret for camera and MQTT credentials - Pulls per-camera RTSP passwords, the Surveillance Station restream credential for the unauthenticated Back Right camera, and Mosquitto MQTT credentials from the 1Password Connect store - `app/externalsecret.yaml`
- Persistent storage layout - `local-path` PVC for `/config` (SQLite, corrupts over NFS), `nfs-client` PVC for `/media/frigate` recordings, an emptyDir cache, and a 512Mi tmpfs `/dev/shm` sized above Frigate's minimum - `app/helmrelease.yaml`
- Networking and access - Traefik ingress for the web UI on 8971 and a MetalLB LoadBalancer at `192.168.20.18` exposing RTSP (8554) and WebRTC (8555 TCP+UDP), with external-dns hostnames - `app/helmrelease.yaml`
- OCIRepository source and Kustomizations - Points at the app-template chart `5.0.1`, wires the app manifests together, and defines the Flux Kustomization depending on `mosquitto` and `onepassword` - `app/ocirepository.yaml`, `app/kustomization.yaml`, `ks.yaml`
- Operational README - Records hardware verification results, measured camera facts, storage rationale, the privileged-mode explanation, and pre-flight steps for the SS credential, detect-stream resolution, Amcrest substreams, HyperBackup exclusion, and volume quota - `README.md`

**Changed:**

- Home-automation kustomization now includes the Frigate app - Added `./frigate/ks.yaml` to the resource list so Flux reconciles the new deployment - `home-automation/kustomization.yaml`