### PR TITLE
fix: update frigate mqtt secret references to mosquitto-secret

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
@@ -38,9 +38,9 @@ spec:
         property: password
     - secretKey: FRIGATE_MQTT_USER
       remoteRef:
-        key: mosquitto
-        property: username
+        key: mosquitto-secret
+        property: MOSQUITTO_MQTT_USERNAME
     - secretKey: FRIGATE_MQTT_PASSWORD
       remoteRef:
-        key: mosquitto
-        property: password
+        key: mosquitto-secret
+        property: MOSQUITTO_MQTT_PASSWORD


### PR DESCRIPTION
**Key Changes:**

- Updated Frigate's MQTT credential references to use the `mosquitto-secret` store key
- Aligned property names with the standardized `MOSQUITTO_MQTT_*` naming convention

**Changed:**

- MQTT credential sourcing - Modified `externalsecret.yaml` to pull `FRIGATE_MQTT_USER` and `FRIGATE_MQTT_PASSWORD` from the `mosquitto-secret` remote key instead of `mosquitto`, using the `MOSQUITTO_MQTT_USERNAME` and `MOSQUITTO_MQTT_PASSWORD` properties to match the updated secret structure