### PR TITLE
fix: quote frigate config version to prevent yaml type coercion

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -201,4 +201,4 @@ data:
                 - record
                 - detect
 
-    version: 0.17
+    version: "0.17"


### PR DESCRIPTION
**Key Changes:**

- Quoted the Frigate config `version` value to ensure it's parsed as a string rather than a float

**Changed:**

- Version value formatting - Changed `version: 0.17` to `version: "0.17"` in the Frigate ConfigMap to prevent YAML from coercing the value into a numeric type, which could cause parsing or validation errors - `kubernetes/apps/home-automation/frigate/app/configmap.yaml`