### PR TITLE
feat: configure frigate https ingress transport and update back_right camera

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -94,8 +94,6 @@ data:
           - rtsp://admin:{FRIGATE_BACK_LEFT_PASSWORD}@192.168.40.202:554/Streaming/Channels/101
         back_left_sub:
           - rtsp://admin:{FRIGATE_BACK_LEFT_PASSWORD}@192.168.40.202:554/Streaming/Channels/102
-        back_right:
-          - rtsp://syno:{FRIGATE_SYNO_RTSP_PASSWORD}@192.168.20.210:554/Sms=12.unicast#media=video
         living_room:
           - rtsp://admin:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.40.204:554/cam/realmonitor?channel=1&subtype=0
         garage:
@@ -164,9 +162,11 @@ data:
           fps: 5
         ffmpeg:
           hwaccel_args: preset-rk-h265
+          input_args: preset-rtsp-generic
+          output_args:
+            record: preset-record-generic
           inputs:
-            - path: rtsp://127.0.0.1:8554/back_right
-              input_args: preset-rtsp-restream
+            - path: rtsp://syno:{FRIGATE_SYNO_RTSP_PASSWORD}@192.168.20.210:554/Sms=12.unicast
               roles:
                 - record
                 - detect

--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -95,7 +95,7 @@ data:
         back_left_sub:
           - rtsp://admin:{FRIGATE_BACK_LEFT_PASSWORD}@192.168.40.202:554/Streaming/Channels/102
         back_right:
-          - rtsp://syno:{FRIGATE_SYNO_RTSP_PASSWORD}@192.168.20.210:554/Sms=12.unicast
+          - rtsp://syno:{FRIGATE_SYNO_RTSP_PASSWORD}@192.168.20.210:554/Sms=12.unicast#media=video
         living_room:
           - rtsp://admin:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.40.204:554/cam/realmonitor?channel=1&subtype=0
         garage:

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -122,6 +122,9 @@ spec:
     ingress:
       app:
         className: ingress-traefik
+        annotations:
+          traefik.ingress.kubernetes.io/service.serversscheme: https
+          traefik.ingress.kubernetes.io/service.serverstransport: home-automation-frigate-transport@kubernetescrd
         hosts:
           - host: &host frigate.techvomit.xyz
             paths:
@@ -167,7 +170,7 @@ spec:
       dshm:
         type: emptyDir
         medium: Memory
-        sizeLimit: 512Mi
+        sizeLimit: 1Gi
         globalMounts:
           - path: /dev/shm
       dev-dri:

--- a/kubernetes/apps/home-automation/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./configmap.yaml
+  - ./serverstransport.yaml

--- a/kubernetes/apps/home-automation/frigate/app/serverstransport.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/serverstransport.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/traefik.io/serverstransport_v1alpha1.json
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: frigate-transport
+  namespace: home-automation
+spec:
+  insecureSkipVerify: true
+  forwardingTimeouts:
+    dialTimeout: 30s
+    responseHeaderTimeout: 60s
+    idleConnTimeout: 90s


### PR DESCRIPTION
**Key Changes:**

- Added a Traefik ServersTransport resource to enable HTTPS backend connections for Frigate with insecure verification skipped
- Reconfigured the back_right camera to connect directly to the Synology RTSP stream instead of the internal restream endpoint
- Doubled the shared memory size limit and applied HTTPS scheme annotations to the Frigate ingress

**Added:**

- Traefik ServersTransport configuration - Created `serverstransport.yaml` defining `frigate-transport` with `insecureSkipVerify` and forwarding timeouts (dial, response header, and idle connection), and registered it in `kustomization.yaml`
- HTTPS ingress annotations - Added `serversscheme: https` and `serverstransport` annotations to the Frigate ingress in `helmrelease.yaml` to route backend traffic over HTTPS using the new transport

**Changed:**

- back_right camera source - Replaced the internal restream path (`rtsp://127.0.0.1:8554/back_right`) with a direct Synology RTSP stream and moved the corresponding go2rtc stream definition; added `preset-rtsp-generic` input args and `preset-record-generic` record output args in `configmap.yaml`
- Shared memory allocation - Increased the `dshm` emptyDir memory size limit from 512Mi to 1Gi in `helmrelease.yaml`

**Removed:**

- go2rtc back_right stream entry - Removed the `back_right` stream definition that previously referenced the Synology unicast source in `configmap.yaml`, as the camera now connects directly