### PR TITLE
fix: move traefik service annotations from ingress to service

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -100,6 +100,9 @@ spec:
     service:
       app:
         controller: frigate
+        annotations:
+          traefik.ingress.kubernetes.io/service.serversscheme: https
+          traefik.ingress.kubernetes.io/service.serverstransport: home-automation-frigate-transport@kubernetescrd
         ports:
           http:
             port: 8971
@@ -122,9 +125,6 @@ spec:
     ingress:
       app:
         className: ingress-traefik
-        annotations:
-          traefik.ingress.kubernetes.io/service.serversscheme: https
-          traefik.ingress.kubernetes.io/service.serverstransport: home-automation-frigate-transport@kubernetescrd
         hosts:
           - host: &host frigate.techvomit.xyz
             paths:


### PR DESCRIPTION
**Key Changes:**

- Relocated Traefik HTTPS scheme and transport annotations from the ingress resource to the service resource
- Ensures Traefik correctly applies the HTTPS server scheme and custom transport at the service level

**Changed:**

- Traefik annotation placement in the Frigate HelmRelease - Moved `traefik.ingress.kubernetes.io/service.serversscheme` and `traefik.ingress.kubernetes.io/service.serverstransport` annotations from the `ingress.app` block to the `service.app` block so the HTTPS backend scheme and `home-automation-frigate-transport@kubernetescrd` transport are applied to the service controller rather than the ingress