### PR TITLE
feat: add authentik forward auth for frigate

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -16,6 +16,15 @@ data:
       topic_prefix: frigate
       client_id: frigate
 
+    auth:
+      enabled: false
+
+    proxy:
+      header_map:
+        user: x-authentik-username
+      default_role: admin
+      logout_url: /outpost.goauthentik.io/sign_out
+
     detectors:
       rknn:
         type: rknn

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -125,6 +125,8 @@ spec:
     ingress:
       app:
         className: ingress-traefik
+        annotations:
+          traefik.ingress.kubernetes.io/router.middlewares: networking-authentik@kubernetescrd
         hosts:
           - host: &host frigate.techvomit.xyz
             paths:

--- a/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
+++ b/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
@@ -137,6 +137,14 @@ data:
         attrs:
           name: Immich Users
 
+      - model: authentik_core.group
+        id: frigate-users
+        identifiers:
+          name: Frigate Users
+        state: present
+        attrs:
+          name: Frigate Users
+
       # Custom Scope Mapping for Home Assistant groups and admin status
       - model: authentik_providers_oauth2.scopemapping
         id: homeassistant-groups-scope
@@ -256,6 +264,25 @@ data:
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           mode: forward_single
           external_host: "https://adguard.techvomit.xyz"
+          cookie_domain: "techvomit.xyz"
+          skip_path_regex: ""
+          basic_auth_enabled: false
+          intercept_header_auth: true
+          access_token_validity: "minutes=5"
+          refresh_token_validity: "days=30"
+
+      # Proxy Provider for Frigate (Forward Auth)
+      - model: authentik_providers_proxy.proxyprovider
+        id: frigate-provider
+        identifiers:
+          name: Frigate
+        state: present
+        attrs:
+          name: Frigate
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: forward_single
+          external_host: "https://frigate.techvomit.xyz"
           cookie_domain: "techvomit.xyz"
           skip_path_regex: ""
           basic_auth_enabled: false
@@ -546,6 +573,20 @@ data:
           meta_description: "AdGuard Home - Network-wide DNS Ad Blocker"
           policy_engine_mode: any
 
+      # Application for Frigate
+      - model: authentik_core.application
+        id: frigate-app
+        identifiers:
+          slug: frigate
+        state: present
+        attrs:
+          name: Frigate
+          slug: frigate
+          provider: !KeyOf frigate-provider
+          meta_launch_url: "https://frigate.techvomit.xyz"
+          meta_description: "Frigate NVR - Camera Monitoring and Recording"
+          policy_engine_mode: any
+
       # Expression policy for group checking
       - model: authentik_policies_expression.expressionpolicy
         id: traefik-admin-policy
@@ -636,6 +677,16 @@ data:
           name: immich-user-policy
           expression: |
             return ak_is_group_member(request.user, name="Immich Users")
+
+      - model: authentik_policies_expression.expressionpolicy
+        id: frigate-user-policy
+        identifiers:
+          name: frigate-user-policy
+        state: present
+        attrs:
+          name: frigate-user-policy
+          expression: |
+            return ak_is_group_member(request.user, name="Frigate Users")
 
       # Policy binding for Traefik application
       - model: authentik_policies.policybinding
@@ -736,6 +787,17 @@ data:
           enabled: true
           order: 0
 
+      # Policy binding for Frigate application
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf frigate-app
+          policy: !KeyOf frigate-user-policy
+          order: 0
+        state: present
+        attrs:
+          enabled: true
+          order: 0
+
       # Assign provider to embedded outpost
       - model: authentik_outposts.outpost
         identifiers:
@@ -745,3 +807,4 @@ data:
             - !KeyOf traefik-provider
             - !KeyOf guacamole-provider
             - !KeyOf adguard-provider
+            - !KeyOf frigate-provider


### PR DESCRIPTION
**Key Changes:**

- Integrated Frigate with Authentik using forward authentication via a Traefik middleware
- Added a complete Authentik blueprint configuration for Frigate, including a proxy provider, application, user group, and access policy
- Configured Frigate to trust proxy authentication headers for user identity and role mapping

**Added:**

- Frigate proxy authentication configuration - Added a `proxy` block in `configmap.yaml` mapping the `x-authentik-username` header to the Frigate user, setting a default `admin` role, and defining the Authentik logout URL; also explicitly disabled Frigate's built-in `auth`
- Authentik forward auth middleware - Added the `networking-authentik@kubernetescrd` Traefik middleware annotation to the Frigate ingress in `helmrelease.yaml` to enforce authentication
- Frigate Authentik resources - Added a "Frigate Users" group, a `forward_single` proxy provider, a Frigate application, a group-membership expression policy, and a policy binding in `authentik-oauth-blueprint.yaml`
- Frigate provider assignment - Added the Frigate proxy provider to the embedded Authentik outpost so forward auth requests are handled