### PR TITLE
feat: add back right camera with go2rtc restream to frigate

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -103,6 +103,10 @@ data:
           - rtsp://admin:{FRIGATE_BACK_LEFT_PASSWORD}@192.168.40.202:554/Streaming/Channels/101
         back_left_sub:
           - rtsp://admin:{FRIGATE_BACK_LEFT_PASSWORD}@192.168.40.202:554/Streaming/Channels/102
+        back_right:
+          - rtsp://admin:{FRIGATE_BACK_RIGHT_PASSWORD}@192.168.40.203:554/Streaming/Channels/101
+        back_right_sub:
+          - rtsp://admin:{FRIGATE_BACK_RIGHT_PASSWORD}@192.168.40.203:554/Streaming/Channels/102
         living_room:
           - rtsp://admin:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.40.204:554/cam/realmonitor?channel=1&subtype=0
         garage:
@@ -166,18 +170,19 @@ data:
       back_right:
         detect:
           enabled: true
-          width: 3840
-          height: 2160
+          width: 640
+          height: 480
           fps: 5
         ffmpeg:
           hwaccel_args: preset-rk-h265
-          input_args: preset-rtsp-generic
-          output_args:
-            record: preset-record-generic
           inputs:
-            - path: rtsp://syno:{FRIGATE_SYNO_RTSP_PASSWORD}@192.168.20.210:554/Sms=12.unicast
+            - path: rtsp://127.0.0.1:8554/back_right
+              input_args: preset-rtsp-restream
               roles:
                 - record
+            - path: rtsp://127.0.0.1:8554/back_right_sub
+              input_args: preset-rtsp-restream
+              roles:
                 - detect
 
       living_room:

--- a/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
@@ -24,9 +24,9 @@ spec:
       remoteRef:
         key: Back Left Camera
         property: password
-    - secretKey: FRIGATE_SYNO_RTSP_PASSWORD
+    - secretKey: FRIGATE_BACK_RIGHT_PASSWORD
       remoteRef:
-        key: synology-surveillance-rtsp
+        key: Back Right Camera
         property: password
     - secretKey: FRIGATE_LIVING_ROOM_PASSWORD
       remoteRef:


### PR DESCRIPTION
**Key Changes:**

- Added dedicated RTSP streams for the back right camera routed through go2rtc restream
- Migrated back right camera detection from Synology surveillance feed to a direct camera connection
- Updated external secret to source the back right camera password from its own vault entry

**Added:**

- Back right camera streams - Defined `back_right` and `back_right_sub` go2rtc RTSP sources pointing to the camera at `192.168.40.203` in `configmap.yaml`

**Changed:**

- Back right camera configuration - Reworked the `back_right` camera in `configmap.yaml` to consume the go2rtc restream endpoints (`rtsp://127.0.0.1:8554/back_right` and `back_right_sub`) with `preset-rtsp-restream`, splitting record and detect roles across the main and sub streams
- Detection resolution - Reduced detect resolution from 3840x2160 to 640x480 to align with the sub stream for more efficient detection
- External secret mapping - Renamed `FRIGATE_SYNO_RTSP_PASSWORD` to `FRIGATE_BACK_RIGHT_PASSWORD` and repointed the remote reference from `synology-surveillance-rtsp` to the `Back Right Camera` key in `externalsecret.yaml`

**Removed:**

- Synology surveillance feed - Dropped the Synology-based RTSP input (`192.168.20.210`) and its associated generic input/output args for the back right camera in `configmap.yaml`