### PR TITLE
fix: use url-encoded password for back right camera rtsp url

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
@@ -24,10 +24,14 @@ spec:
       remoteRef:
         key: Back Left Camera
         property: password
+    # Uses the URL-encoded password field: the raw password contains "," and "["
+    # which go2rtc's Go URL parser rejects as invalid userinfo. The plaintext
+    # lives in the item's `password` field; `rtsp_encoded_password` holds the
+    # percent-encoded form for the RTSP URL.
     - secretKey: FRIGATE_BACK_RIGHT_PASSWORD
       remoteRef:
         key: Back Right Camera
-        property: password
+        property: rtsp_encoded_password
     - secretKey: FRIGATE_LIVING_ROOM_PASSWORD
       remoteRef:
         key: Living Room Camera


### PR DESCRIPTION
**Key Changes:**

- Switched the Back Right Camera secret to a URL-encoded password to fix go2rtc's URL parser rejecting special characters
- Added inline documentation explaining the encoding requirement

**Added:**

- Explanatory comment - Documented in `externalsecret.yaml` why the encoded password field is used and how the RTSP URL relies on the percent-encoded form

**Changed:**

- Back Right Camera password mapping - Updated the `FRIGATE_BACK_RIGHT_PASSWORD` remote reference in `externalsecret.yaml` to pull from the `rtsp_encoded_password` property instead of the raw `password`, since the plaintext contains "," and "[" characters that go2rtc's Go URL parser rejects as invalid userinfo