### PR TITLE
docs: add automated README generation and refresh cluster documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,11 @@ repos:
         language: script
         entry: .hooks/run-shfmt.sh
         files: \.sh$
+
+      - id: readme-gen
+        name: Regenerate README generated sections
+        language: script
+        entry: hack/readme-gen.sh
+        files: >-
+          ^(README\.md|Taskfile\.yaml|\.taskfiles/.*|docs/.*\.md|kubernetes/apps/.*|\.github/workflows/.*|hack/readme-gen\.sh)$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -22,25 +22,29 @@ _... managed with Flux, Renovate and GitHub Actions_ 🤖
 
 ## 📖 Overview
 
-**Walls of Excellence (woe)** is a comprehensive home operations monorepo
-implementing Infrastructure as Code (IaC) and GitOps practices for managing
-a production-grade Kubernetes cluster.
+**Walls of Excellence (woe)** is a home operations monorepo implementing
+Infrastructure as Code (IaC) and GitOps practices for a multi-architecture
+k3s cluster.
 
 ### Key Features
 
-- **GitOps-Native**: Flux CD for continuous deployment and reconciliation
-- **Automated Provisioning**: Ansible-based k3s cluster deployment (7 nodes)
-- **Secrets Management**: External Secrets Operator with 1Password integration
-- **Comprehensive Observability**: Prometheus, Grafana, Loki, and Alloy
-- **Home Automation**: Home Assistant, MQTT, and smart home services
-- **Security Testing**: Atomic Red Team, TTPForge, and C2 infrastructure
-- **CI/CD**: Automated testing, validation, and dependency updates
+- **GitOps-Native**: Flux (flux-operator + flux-instance) reconciles
+  everything under `kubernetes/apps/`
+- **Automated Provisioning**: Ansible-based k3s deployment across Raspberry
+  Pis, a Radxa ROCK 5B, and VM workers
+- **Secrets Management**: External Secrets Operator backed by 1Password
+- **Comprehensive Observability**: kube-prometheus-stack, Grafana, Loki,
+  Tempo, Alloy, and Vector
+- **Home Automation & Media**: Home Assistant, Frigate, Zigbee2MQTT,
+  Music Assistant, and Immich
+- **Security Testing**: Atomic Red Team, TTPForge, Sliver C2, and hashcat
+- **CI/CD**: GitHub Actions (self-hosted runners via ARC) and Renovate
 
 ### Technology Stack
 
-- **Kubernetes**: k3s (lightweight, production-ready)
-- **GitOps**: Flux CD v2.4.0+
-- **Provisioning**: Ansible 2.11+
+- **Kubernetes**: k3s
+- **GitOps**: Flux CD (managed by flux-operator)
+- **Provisioning**: Ansible
 - **Package Management**: Helm, Helmfile
 - **Secrets**: External Secrets Operator, 1Password
 - **Automation**: Task (go-task)
@@ -59,18 +63,25 @@ a production-grade Kubernetes cluster.
 - [Deployed Applications](#deployed-applications)
 - [Usage](#usage)
 - [Task Categories](#task-categories)
+- [CI/CD](#cicd)
 - [Resources](#resources)
 
 ---
 
 ## 📚 Documentation
 
-- **[Developer Environment Setup](docs/dev.md)** - Complete development
-  workflow guide
-- **[Test Environment](docs/test-environment.md)** - Local testing with
-  kind clusters
-- **[Bootstrap Instructions](kubernetes/bootstrap/README.md)** - Initial
-  cluster setup
+<!-- BEGIN GENERATED: docs -->
+
+- [Developer Environment Setup](docs/dev.md)
+- [Rock5B NVMe Boot Setup](docs/rock5b-nvme-boot.md)
+- [Test Environment](docs/test-environment.md)
+
+<!-- END GENERATED: docs -->
+
+For initial cluster setup, see the
+[Bootstrap Instructions](kubernetes/bootstrap/README.md). Several
+applications also carry a README next to their manifests under
+[`kubernetes/apps/`](kubernetes/apps).
 
 ---
 
@@ -122,6 +133,7 @@ See [Developer Guide](docs/dev.md) for detailed Linux installation instructions.
    ```bash
    gh repo clone CowDogMoo/Walls-of-Excellence woe
    cd woe
+   git submodule update --init
    ```
 
 2. **Set up development environment:**
@@ -179,47 +191,17 @@ task apply-secrets
 
 ```text
 woe/
-├── .github/                    # GitHub Actions workflows
-│   ├── workflows/              # CI/CD pipelines
-│   └── renovate/               # Dependency update configs
-├── .taskfiles/                 # Task definitions
-│   ├── bootstrap/              # Bootstrap tasks
-│   └── test/                   # Testing tasks
-├── docs/                       # Documentation
-│   ├── dev.md                  # Development guide
-│   └── test-environment.md     # Testing guide
-├── hack/                       # Utility scripts
-├── infrastructure/             # Terraform/Terragrunt
-├── k3s-ansible/                # Ansible k3s provisioning
-│   ├── inventory/cowdogmoo/    # 7-node inventory
-│   ├── roles/                  # Ansible roles
-│   ├── molecule/               # Testing scenarios
-│   ├── site.yml                # Main playbook
-│   └── reset.yml               # Teardown playbook
-├── kubernetes/
-│   ├── apps/                   # 16 namespaces, 35+ apps
-│   │   ├── attack-simulation/  # Red team tools
-│   │   ├── c2/                 # Command & control
-│   │   ├── cert-manager/       # TLS management
-│   │   ├── database/           # MySQL
-│   │   ├── external-secrets/   # Secret sync
-│   │   ├── flux-system/        # Flux components
-│   │   ├── guacamole/          # Remote desktop
-│   │   ├── home-automation/    # Smart home services
-│   │   ├── identity/           # Authentik (OIDC)
-│   │   ├── kube-system/        # System components
-│   │   ├── monitoring/         # RunZero
-│   │   ├── networking/         # Traefik, ExternalDNS
-│   │   ├── observability/      # Grafana, Loki, Prometheus
-│   │   └── system-upgrade/     # Upgrade controller
-│   ├── bootstrap/              # Initial setup
-│   │   ├── flux/               # Flux CRDs
-│   │   ├── helmfile.d/         # Helmfile configs
-│   │   └── resources.yaml.j2   # Secret templates
-│   ├── flux/                   # Flux GitOps configs
-│   └── deprecated/             # Legacy configs (skipped)
-├── ansible.cfg                 # Ansible configuration
-└── Taskfile.yaml               # Root task definitions
+├── .github/          # CI workflows and Renovate configuration
+├── .taskfiles/       # Local task definitions (bootstrap, test, ...)
+├── docs/             # Guides and runbooks
+├── hack/             # Utility scripts
+├── infrastructure/   # Terraform/Terragrunt
+├── k3s-ansible/      # Ansible k3s provisioning (git submodule)
+└── kubernetes/
+    ├── apps/         # Flux-managed applications, one directory per namespace
+    ├── bootstrap/    # Initial cluster setup (helmfile.d, Flux install)
+    ├── flux/         # Flux entry-point configuration
+    └── deprecated/   # Retired configs kept for reference
 ```
 
 ---
@@ -228,91 +210,66 @@ woe/
 
 ### Nodes
 
-- **7-node cluster**: k8s1 through k8s7
-- **High Availability**: Multi-master control plane with etcd
-- **Load Balancing**: kube-vip (control plane), MetalLB (services)
-- **CNI Options**: Calico or Cilium (configurable)
+- **Multi-architecture k3s cluster**: PoE-powered Raspberry Pis, a Radxa
+  ROCK 5B (NVMe), and VM workers on Proxmox and macOS (Lima)
+- **High Availability**: Multi-master control plane with embedded etcd
+- **Control Plane VIP**: kube-vip
 
 ### Networking
 
-- **Cluster CIDR**: 10.52.0.0/16
-- **Service CIDR**: 10.53.0.0/16
-- **Load Balancer Range**: 192.168.30.80-192.168.30.90
 - **Ingress**: Traefik with TLS termination
-- **DNS**: External DNS with automatic record management
+- **Load Balancing**: MetalLB for LoadBalancer services
+- **DNS**: ExternalDNS with automatic record management, AdGuard Home for
+  filtering
+- **Remote Access**: Tailscale operator
 
 ### Storage
 
-- **NFS Provisioner**: Dynamic persistent volume provisioning
-- **Persistent Volumes**: Backed by NFS server
+- **NFS**: Dynamic persistent volumes via nfs-subdir-external-provisioner,
+  backed by a Synology NAS
+- **Local**: local-path volumes for latency-sensitive workloads
+
+### Data
+
+- **PostgreSQL**: CloudNative-PG operator
+- **MySQL**: Standalone instance
 
 ### Security
 
 - **Secrets Management**: External Secrets Operator with 1Password
 - **Authentication**: Authentik (OIDC provider)
 - **Certificate Management**: cert-manager with Let's Encrypt
-- **Network Policies**: Calico/Cilium network policies
 
 ---
 
 ## Deployed Applications
 
-### System & Infrastructure
+<!-- BEGIN GENERATED: apps -->
 
-- **NFS Subdir External Provisioner** - Dynamic PVC provisioning
-- **Reflector** - ConfigMap/Secret mirroring
-- **Reloader** - Auto-restart on config changes
-- **System Upgrade Controller** - Coordinated node upgrades
+Flux reconciles **48 applications** across **18 namespaces** from [`kubernetes/apps/`](kubernetes/apps).
 
-### GitOps & Deployment
+| Namespace | Applications |
+| --------- | ------------ |
+| `actions-runner-system` | [actions-runner-controller](kubernetes/apps/actions-runner-system/actions-runner-controller) |
+| `attack-simulation` | [ares](kubernetes/apps/attack-simulation/ares), [atomic-red-team](kubernetes/apps/attack-simulation/atomic-red-team), [ttpforge](kubernetes/apps/attack-simulation/ttpforge) |
+| `c2` | [sliver](kubernetes/apps/c2/sliver) |
+| `cert-manager` | [cert-manager](kubernetes/apps/cert-manager/cert-manager), [synology-cert-sync](kubernetes/apps/cert-manager/synology-cert-sync) |
+| `cracking` | [hashcat](kubernetes/apps/cracking/hashcat) |
+| `database` | [cloudnative-pg](kubernetes/apps/database/cloudnative-pg), [mysql](kubernetes/apps/database/mysql) |
+| `external-secrets` | [external-secrets](kubernetes/apps/external-secrets/external-secrets), [onepassword](kubernetes/apps/external-secrets/onepassword) |
+| `flux-system` | [addons](kubernetes/apps/flux-system/addons), [flux-instance](kubernetes/apps/flux-system/flux-instance), [flux-operator](kubernetes/apps/flux-system/flux-operator), [weave-gitops](kubernetes/apps/flux-system/weave-gitops) |
+| `guacamole` | [guacamole](kubernetes/apps/guacamole/guacamole) |
+| `home-automation` | [frigate](kubernetes/apps/home-automation/frigate), [grocy](kubernetes/apps/home-automation/grocy), [home-assistant](kubernetes/apps/home-automation/home-assistant), [mosquitto](kubernetes/apps/home-automation/mosquitto), [music-assistant](kubernetes/apps/home-automation/music-assistant), [printer-monitor](kubernetes/apps/home-automation/printer-monitor), [troy-backup](kubernetes/apps/home-automation/troy-backup), [zigbee2mqtt](kubernetes/apps/home-automation/zigbee2mqtt) |
+| `identity` | [authentik](kubernetes/apps/identity/authentik) |
+| `inference` | [ollama](kubernetes/apps/inference/ollama) |
+| `kube-system` | [descheduler](kubernetes/apps/kube-system/descheduler), [nfs-subdir-external-provisioner](kubernetes/apps/kube-system/nfs-subdir-external-provisioner), [reflector](kubernetes/apps/kube-system/reflector), [reloader](kubernetes/apps/kube-system/reloader) |
+| `media` | [immich](kubernetes/apps/media/immich) |
+| `monitoring` | [runzero-explorer](kubernetes/apps/monitoring/runzero-explorer) |
+| `networking` | [adguard-home](kubernetes/apps/networking/adguard-home), [external-dns](kubernetes/apps/networking/external-dns), [ingress-traefik](kubernetes/apps/networking/ingress-traefik), [tailscale-operator](kubernetes/apps/networking/tailscale-operator) |
+| `observability` | [alloy](kubernetes/apps/observability/alloy), [blackbox-exporter](kubernetes/apps/observability/blackbox-exporter), [goldilocks](kubernetes/apps/observability/goldilocks), [grafana](kubernetes/apps/observability/grafana), [kube-prometheus-stack](kubernetes/apps/observability/kube-prometheus-stack), [loki](kubernetes/apps/observability/loki), [robusta](kubernetes/apps/observability/robusta), [tempo](kubernetes/apps/observability/tempo), [unpoller](kubernetes/apps/observability/unpoller), [vector](kubernetes/apps/observability/vector) |
+| `system-upgrade` | [system-upgrade-controller](kubernetes/apps/system-upgrade/system-upgrade-controller) |
 
-- **Flux Operator** - Flux cluster management
-- **Flux Instance** - Git synchronization
-- **Weave GitOps** - Flux UI
-
-### Security & Identity
-
-- **Authentik** - OIDC authentication provider
-- **cert-manager** - TLS certificate lifecycle
-- **external-secrets** - 1Password integration
-- **Guacamole** - Remote desktop gateway
-
-### Network Services
-
-- **Traefik** - Ingress controller
-- **External DNS** - DNS automation
-
-### Observability
-
-- **Prometheus** - Metrics collection
-- **Grafana** - Visualization and dashboards
-- **Loki** - Log aggregation
-- **Alloy** - Telemetry collection
-- **Vector** - Log processing
-- **AlertManager** - Alert routing
-- **Unpoller** - UniFi metrics
-
-### Home Automation
-
-- **Home Assistant** - Home automation platform
-- **Mosquitto** - MQTT broker
-- **Music Assistant** - Music server
-- **Grocy** - Inventory management
-- **Printer Monitor** - Printer status monitoring
-
-### Security Testing
-
-- **Atomic Red Team** - Attack simulation
-- **TTPForge** - Threat modeling
-- **Sliver** - C2 framework
-
-### Monitoring
-
-- **RunZero Explorer** - Network discovery
-
-### Database
-
-- **MySQL** - SQL database backend
+<!-- END GENERATED: apps -->
 
 ---
 
@@ -330,17 +287,12 @@ task provision-nodes
 
 # Check cluster status
 task ping
-task ping-masters
-task ping-nodes
+task check-inventory
 
 # Reboot nodes
 task reboot NODE=k8s1
 task reboot-all
-```
 
-### Node Operations
-
-```bash
 # Run command on all nodes
 task run-cmd-all -- 'uptime'
 
@@ -374,9 +326,6 @@ task apply-secrets
 # Sync Flux system
 flux reconcile ks flux-system --with-source
 
-# Sync cluster apps
-flux reconcile ks cluster-apps --with-source -n flux-system
-
 # Check Flux status
 flux get all -A
 
@@ -404,63 +353,48 @@ task test:status
 task test:destroy
 ```
 
-### Ansible Operations
-
-```bash
-# Lint Ansible playbooks
-task ansible:lint-ansible
-
-# Run Molecule tests
-task ansible:run-molecule-tests
-
-# List Ansible hosts
-task ansible:list-hosts
-```
-
-### Terraform Operations
-
-```bash
-# Format and validate
-task terraform:tf-check
-
-# Plan infrastructure changes
-task terraform:tf-plan
-
-# Apply infrastructure changes
-task terraform:tf-apply
-```
-
 ### Troubleshooting
 
 ```bash
 # Remove stuck namespaces
 task k8s:destroy-stuck-ns
 
-# Completely remove Rancher (if installed)
-task destroy-rancher
-
 # Reset cluster (destroy and rebuild)
 task reset
-task reset-masters
-task reset-nodes
+task provision
+task bootstrap
 ```
 
 ---
 
 ## Task Categories
 
-The project uses [Task](https://taskfile.dev/) with the following categories:
+The project uses [Task](https://taskfile.dev/). Remote categories are pulled
+from [taskfile-templates](https://github.com/CowDogMoo/taskfile-templates)
+at runtime; the first run prompts to trust them (or run `task -y`).
 
-| Category       | Description                | Example Tasks               |
-| -------------- | -------------------------- | --------------------------- |
-| **Root tasks** | Core cluster operations    | `provision`, `ping`         |
-| `ansible:*`    | Ansible automation/testing | `ansible:lint-ansible`      |
-| `k8s:*`        | Kubernetes management      | `k8s:destroy-stuck-ns`      |
-| `terraform:*`  | Infrastructure as Code     | `terraform:tf-check`        |
-| `pre-commit:*` | Code quality/linting       | `pre-commit:run-pre-commit` |
-| `renovate:*`   | Renovate bot operations    | `renovate:dry-run`          |
-| `bootstrap:*`  | Cluster bootstrap          | `bootstrap:wait`            |
-| `test:*`       | Local testing with kind    | `test:create`, `test:apply` |
+<!-- BEGIN GENERATED: tasks -->
+
+Root tasks (run as `task <name>`): `default`, `check-inventory`,
+`run-cmd-all`, `run-cmd`, `reboot`, `reboot-all`, `shutdown-cluster`, `ping`,
+`ping-masters`, `ping-nodes`, `provision`, `provision-masters`,
+`provision-nodes`, `reset`, `reset-masters`, `reset-nodes`, `apply-secrets`,
+`destroy-rancher`, `reconcile`.
+
+| Category | Defined in |
+| -------- | ---------- |
+| `ansible:*` | [CowDogMoo/taskfile-templates/ansible](https://github.com/CowDogMoo/taskfile-templates/blob/main/ansible/Taskfile.yaml) |
+| `bootstrap:*` | [.taskfiles/bootstrap](.taskfiles/bootstrap/Taskfile.yaml) |
+| `guacamole:*` | [.taskfiles/guacamole](.taskfiles/guacamole/Taskfile.yaml) |
+| `k8s:*` | [CowDogMoo/taskfile-templates/k8s](https://github.com/CowDogMoo/taskfile-templates/blob/main/k8s/Taskfile.yaml) |
+| `onepassword:*` | [CowDogMoo/taskfile-templates/secrets/onepassword](https://github.com/CowDogMoo/taskfile-templates/blob/main/secrets/onepassword/Taskfile.yaml) |
+| `pre-commit:*` | [CowDogMoo/taskfile-templates/pre-commit](https://github.com/CowDogMoo/taskfile-templates/blob/main/pre-commit/Taskfile.yaml) |
+| `proxmox:*` | [.taskfiles/proxmox](.taskfiles/proxmox/Taskfile.yaml) |
+| `renovate:*` | [CowDogMoo/taskfile-templates/renovate](https://github.com/CowDogMoo/taskfile-templates/blob/main/renovate/Taskfile.yaml) |
+| `terraform:*` | [CowDogMoo/taskfile-templates/terraform](https://github.com/CowDogMoo/taskfile-templates/blob/main/terraform/Taskfile.yaml) |
+| `test:*` | [.taskfiles/test](.taskfiles/test/Taskfile.yaml) |
+
+<!-- END GENERATED: tasks -->
 
 Run `task -l` to see all available tasks with descriptions.
 
@@ -470,63 +404,30 @@ Run `task -l` to see all available tasks with descriptions.
 
 ### Automated Workflows
 
-- **Pre-commit**: Runs on every commit and PR
-- **Test Manifests**: Validates and tests deployments in kind clusters
-- **Renovate**: Weekly dependency updates (Sunday & Wednesday 00:00 UTC)
-- **Semgrep**: Security linting
+<!-- BEGIN GENERATED: workflows -->
 
-### Renovate Features
+- [Labeler](.github/workflows/meta-labeler.yaml)
+- [Meta Sync labels](.github/workflows/meta-sync-labels.yaml)
+- [Pre-Commit](.github/workflows/pre-commit.yaml)
+- [🤖 Renovate](.github/workflows/renovate.yaml)
+- [🚨 Semgrep Analysis](.github/workflows/semgrep.yaml)
+- [🧪 Test Kubernetes Manifests](.github/workflows/test-manifests.yaml)
 
-- **Semantic commits**: Follows conventional commit format
-- **Auto-merge**: Digest updates and branch creation
-- **Custom managers**: Flux and helm-values detection
-- **Pre-commit integration**: Runs hooks on update PRs
+<!-- END GENERATED: workflows -->
 
-View workflow runs:
+### Renovate
 
-```bash
-gh run list
-gh run view <run-id>
-gh run watch
-```
+Renovate automatically opens PRs for Helm chart, container image, GitHub
+Action, and Flux component updates, using conventional commit messages and
+custom managers for Flux and helm-values detection.
 
----
+### README Generation
 
-## Maintenance
-
-### Regular Updates
-
-Renovate automatically creates PRs for:
-
-- Helm chart updates
-- Docker image updates
-- GitHub Action updates
-- Flux component updates
-
-### Manual Updates
-
-```bash
-# Update Flux
-flux install --export > kubernetes/bootstrap/flux/gotk-components.yaml
-
-# Update CRDs
-task bootstrap:crds
-
-# Reconcile changes
-flux reconcile ks flux-system --with-source
-```
-
-### Cluster Reset
-
-If the cluster becomes unrecoverable:
-
-```bash
-# Complete cluster reset and rebuild
-task reset          # Reset k3s cluster
-task provision      # Reprovision with Ansible
-task bootstrap      # Bootstrap from scratch
-flux get ks -A      # Verify reconciliation
-```
+The application, documentation, task, and workflow listings in this README
+are generated from repository state by
+[`hack/readme-gen.sh`](hack/readme-gen.sh). A pre-commit hook keeps them
+current — edit the source of truth (manifests, docs, taskfiles), not the
+generated blocks.
 
 ---
 

--- a/hack/readme-gen.sh
+++ b/hack/readme-gen.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Regenerate the marked sections of README.md from repository state.
+#
+# Sections (between "<!-- BEGIN GENERATED: <name> -->" markers):
+#   apps      - applications under kubernetes/apps, grouped by namespace
+#   docs      - guides under docs/
+#   tasks     - root tasks and task categories from Taskfile.yaml
+#   workflows - GitHub Actions workflows
+#
+# Only tracked files (git ls-files) feed the output so local and CI runs
+# agree regardless of untracked files or submodule state. Exits non-zero
+# when README.md changed so pre-commit surfaces the drift.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+README="README.md"
+
+if ! command -v yq > /dev/null 2>&1; then
+    echo "Error: yq is required to regenerate ${README}" >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+# First "# " heading of a markdown file, falling back to its path.
+md_title() {
+    local file="$1" title
+    title="$(awk '/^# / { sub(/^# /, ""); print; exit }' "${file}")"
+    echo "${title:-${file}}"
+}
+
+gen_apps() {
+    local ns app prev_ns="" row_apps="" ns_count=0 app_count=0 table=""
+
+    while IFS=$'\t' read -r ns app; do
+        app_count=$((app_count + 1))
+        if [[ ${ns} != "${prev_ns}" ]]; then
+            if [[ -n ${prev_ns} ]]; then
+                table+="| \`${prev_ns}\` | ${row_apps} |"$'\n'
+            fi
+            ns_count=$((ns_count + 1))
+            prev_ns="${ns}"
+            row_apps=""
+        fi
+        if [[ -n ${row_apps} ]]; then
+            row_apps+=", "
+        fi
+        row_apps+="[${app}](kubernetes/apps/${ns}/${app})"
+    done < <(git ls-files 'kubernetes/apps/*' \
+        | awk -F/ 'NF >= 5 { print $3 "\t" $4 }' \
+        | sort -u)
+    if [[ -n ${prev_ns} ]]; then
+        table+="| \`${prev_ns}\` | ${row_apps} |"$'\n'
+    fi
+
+    echo "Flux reconciles **${app_count} applications** across" \
+        "**${ns_count} namespaces** from [\`kubernetes/apps/\`](kubernetes/apps)."
+    echo ""
+    echo "| Namespace | Applications |"
+    echo "| --------- | ------------ |"
+    printf '%s' "${table}"
+}
+
+gen_docs() {
+    local f
+    while IFS= read -r f; do
+        printf -- '- [%s](%s)\n' "$(md_title "${f}")" "${f}"
+    done < <(git ls-files 'docs/*.md' | sort)
+}
+
+gen_tasks() {
+    local root_tasks name src text url
+    # shellcheck disable=SC2016  # literal backticks, not command substitution
+    root_tasks="$(yq '.tasks | keys | .[]' Taskfile.yaml \
+        | grep -v '^#' \
+        | sed 's/^/`/; s/$/`/' \
+        | paste -s -d ',' - \
+        | sed 's/,/, /g')"
+
+    echo "Root tasks (run as \`task <name>\`): ${root_tasks}." \
+        | fold -s -w 79 \
+        | sed 's/ *$//'
+    echo ""
+    echo "| Category | Defined in |"
+    echo "| -------- | ---------- |"
+    while IFS=$'\t' read -r name src; do
+        if [[ ${src} == https://raw.githubusercontent.com/* ]]; then
+            url="$(echo "${src}" \
+                | sed -E 's|^https://raw\.githubusercontent\.com/([^/]+/[^/]+)/([^/]+)/|https://github.com/\1/blob/\2/|')"
+            text="$(echo "${src}" \
+                | sed -E 's|^https://raw\.githubusercontent\.com/([^/]+/[^/]+)/[^/]+/(.*)/Taskfile\.ya?ml$|\1/\2|')"
+        else
+            url="${src#./}"
+            text="$(dirname "${url}")"
+        fi
+        echo "| \`${name}:*\` | [${text}](${url}) |"
+    done < <(yq '.includes | to_entries | .[]
+        | .key + "\t" + ((.value | select(kind == "map") | .taskfile) // .value)' \
+        Taskfile.yaml | sort)
+}
+
+gen_workflows() {
+    local f name
+    while IFS= read -r f; do
+        name="$(yq '.name // ""' "${f}")"
+        printf -- '- [%s](%s)\n' "${name:-$(basename "${f}")}" "${f}"
+    done < <(git ls-files '.github/workflows/*.y*ml' | sort)
+}
+
+replace_block() {
+    local name="$1" content_file="$2"
+    local begin="<!-- BEGIN GENERATED: ${name} -->"
+    local end="<!-- END GENERATED: ${name} -->"
+    local begin_line end_line
+
+    begin_line="$(grep -nxF "${begin}" "${README}" | head -n1 | cut -d: -f1 || true)"
+    end_line="$(grep -nxF "${end}" "${README}" | head -n1 | cut -d: -f1 || true)"
+    if [[ -z ${begin_line} || -z ${end_line} ]] || ((begin_line >= end_line)); then
+        echo "Error: missing or malformed markers for section '${name}' in ${README}" >&2
+        exit 1
+    fi
+
+    {
+        head -n "${begin_line}" "${README}"
+        echo ""
+        cat "${content_file}"
+        echo ""
+        tail -n +"${end_line}" "${README}"
+    } > "${TMP_DIR}/readme"
+    mv "${TMP_DIR}/readme" "${README}"
+}
+
+main() {
+    local before="${TMP_DIR}/before" section
+    cp "${README}" "${before}"
+
+    for section in apps docs tasks workflows; do
+        "gen_${section}" > "${TMP_DIR}/${section}.md"
+        replace_block "${section}" "${TMP_DIR}/${section}.md"
+    done
+
+    if ! cmp -s "${before}" "${README}"; then
+        echo "Regenerated sections in ${README}; review and re-stage it."
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
**Key Changes:**

- Introduced `hack/readme-gen.sh` to auto-generate README sections (apps, docs, tasks, workflows) from repository state
- Added a pre-commit hook that regenerates README sections and surfaces drift on relevant file changes
- Overhauled README to reflect the current multi-architecture k3s cluster, 48 applications across 18 namespaces, and remote taskfile templates

**Added:**

- README generation script - Created `hack/readme-gen.sh` to build the applications table, documentation links, root task list with category sources, and GitHub Actions workflow list from tracked files via `git ls-files` and `yq`, ensuring parity between local and CI runs and exiting non-zero when drift is detected
- Pre-commit integration - Added a `readme-gen` hook in `.pre-commit-config.yaml` that runs the generation script when README, taskfiles, docs, app manifests, or workflows change
- Generated marker blocks in `README.md` - Introduced `BEGIN/END GENERATED` sections for docs, apps, tasks, and workflows to hold auto-populated content, plus a new CI/CD table of contents entry and a "README Generation" section documenting the workflow

**Changed:**

- Cluster overview and feature set - Rewrote the overview to describe a home operations k3s cluster spanning Raspberry Pis, a Radxa ROCK 5B, and VM workers, and expanded features to include Frigate, Zigbee2MQTT, Immich, Tempo, Vector, hashcat, and ARC-based self-hosted runners
- Repository structure and architecture docs - Simplified the directory tree, noted `k3s-ansible` as a git submodule (adding `git submodule update --init` to setup), and refreshed networking, storage, data, and security sections with current tooling (MetalLB, AdGuard Home, Tailscale, CloudNative-PG, local-path)
- Usage and task documentation - Updated command examples (`task check-inventory`, `task reconcile`, reset/provision/bootstrap flow) and replaced the static task category table with a generated list referencing remote taskfile-templates

**Removed:**

- Static documentation content - Removed hardcoded application listings, node/CIDR specifics, Ansible/Terraform operation snippets, and the manual Maintenance section now superseded by generated content and streamlined guidance