### PR TITLE
fix: reduce frigate detection resolution across all cameras

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -116,8 +116,8 @@ data:
       front_left:
         detect:
           enabled: true
-          width: 1280
-          height: 720
+          width: 640
+          height: 480
           fps: 5
         ffmpeg:
           hwaccel_args: preset-rk-h265
@@ -134,8 +134,8 @@ data:
       front_right:
         detect:
           enabled: true
-          width: 1280
-          height: 720
+          width: 640
+          height: 480
           fps: 5
         ffmpeg:
           hwaccel_args: preset-rk-h265
@@ -152,8 +152,8 @@ data:
       back_left:
         detect:
           enabled: true
-          width: 1280
-          height: 720
+          width: 640
+          height: 480
           fps: 5
         ffmpeg:
           hwaccel_args: preset-rk-h265
@@ -170,8 +170,8 @@ data:
       back_right:
         detect:
           enabled: true
-          width: 1280
-          height: 720
+          width: 640
+          height: 480
           fps: 5
         ffmpeg:
           hwaccel_args: preset-rk-h265


### PR DESCRIPTION
**Key Changes:**

- Lowered detection resolution from 1280x720 to 640x480 for all four cameras
- Applied consistent detection settings across front and back camera pairs
- Reduced processing load by using a smaller detection frame size

**Changed:**

- Camera detection resolution - Updated `front_left`, `front_right`, `back_left`, and `back_right` camera detection settings in `configmap.yaml` from 1280x720 to 640x480, reducing the detection frame size to lower CPU/hardware demand while maintaining the 5 fps detection rate