### PR TITLE
feat: add HD camera group to frigate configuration

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/configmap.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/configmap.yaml
@@ -85,6 +85,18 @@ data:
           - car
           - dog
 
+    camera_groups:
+      HD:
+        order: 1
+        icon: LuVideo
+        cameras:
+          - front_left
+          - front_right
+          - back_left
+          - back_right
+          - living_room
+          - garage
+
     go2rtc:
       webrtc:
         candidates:


### PR DESCRIPTION
**Key Changes:**

- Introduced a new HD camera group in the Frigate configuration to organize high-definition cameras
- Grouped six cameras under a single logical view with custom ordering and icon

**Added:**

- HD camera group - Added a `camera_groups` section in `configmap.yaml` defining an "HD" group with display order, `LuVideo` icon, and six member cameras (front_left, front_right, back_left, back_right, living_room, garage) for improved camera organization in the Frigate UI