### PR TITLE
docs: streamline README and add automated section generation

### DIFF
--- a/.hooks/linters/markdownlint.json
+++ b/.hooks/linters/markdownlint.json
@@ -3,7 +3,7 @@
   "MD004": false,
   "MD013": {
     "code_blocks": false,
-    "line_length": false
+    "line_length": 80
   },
   "MD029": false,
   "MD033": false,

--- a/README.md
+++ b/README.md
@@ -87,40 +87,13 @@ applications also carry a README next to their manifests under
 
 ## Prerequisites
 
-### Required Tools
+Managing the cluster requires [Task](https://taskfile.dev/),
+the [Flux CLI](https://fluxcd.io/flux/), kubectl, Helm, Helmfile, Kustomize,
+yq, the [1Password CLI](https://developer.1password.com/docs/cli/), Ansible,
+and Terraform.
 
-- **[Task](https://taskfile.dev/installation/)** - Task runner for automation
-- **[Flux CLI](https://fluxcd.io/flux/installation/)** - GitOps toolkit
-- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** - Kubernetes CLI
-- **[Helm](https://helm.sh/docs/intro/install/)** - Package manager
-- **[Helmfile](https://helmfile.readthedocs.io/)** - Helm release orchestrator
-- **[Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)**
-  \- Manifest customization
-- **[yq](https://github.com/mikefarah/yq)** - YAML processor
-- **[1Password CLI](https://developer.1password.com/docs/cli/)** - Secret
-  management
-- **[Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)**
-  \- Infrastructure provisioning
-- **[Terraform](https://www.terraform.io/downloads)** - Infrastructure as Code
-
-### Quick Install (macOS)
-
-```bash
-brew install go-task/tap/go-task
-brew install fluxcd/tap/flux
-brew install kubectl
-brew install helm
-brew install helmfile
-brew install kustomize
-brew install yq
-brew install ansible
-brew install terraform
-brew install --cask 1password-cli
-```
-
-### Quick Install (Linux)
-
-See [Developer Guide](docs/dev.md) for detailed Linux installation instructions.
+See the [Developer Guide](docs/dev.md#dependencies) for installation
+instructions on macOS and Linux.
 
 ---
 
@@ -275,95 +248,12 @@ Flux reconciles **48 applications** across **18 namespaces** from [`kubernetes/a
 
 ## Usage
 
-### Cluster Management
+Day-to-day operations — provisioning, node management, Flux, debugging, and
+cluster recovery — are documented in the [Developer Guide](docs/dev.md).
+Local testing with kind is covered in the
+[Test Environment guide](docs/test-environment.md).
 
-```bash
-# Provision entire k3s cluster
-task provision
-
-# Provision specific node groups
-task provision-masters
-task provision-nodes
-
-# Check cluster status
-task ping
-task check-inventory
-
-# Reboot nodes
-task reboot NODE=k8s1
-task reboot-all
-
-# Run command on all nodes
-task run-cmd-all -- 'uptime'
-
-# Run command on specific node
-task run-cmd NODE=k8s1 -- 'df -h'
-```
-
-### GitOps Operations
-
-```bash
-# Bootstrap cluster from scratch
-task bootstrap
-
-# Individual bootstrap steps
-task bootstrap:wait        # Wait for nodes
-task bootstrap:namespaces  # Create namespaces
-task bootstrap:resources   # Apply secrets
-task bootstrap:crds        # Apply CRDs
-task bootstrap:apps        # Deploy core apps
-
-# Reconcile Kubernetes resources
-task reconcile
-
-# Apply secrets
-task apply-secrets
-```
-
-### Flux Synchronization
-
-```bash
-# Sync Flux system
-flux reconcile ks flux-system --with-source
-
-# Check Flux status
-flux get all -A
-
-# View Flux logs
-flux logs --all-namespaces --follow
-```
-
-### Development Workflow
-
-```bash
-# View all available tasks
-task -l
-
-# Run pre-commit hooks
-task pre-commit:run-pre-commit
-
-# Validate manifests locally
-task test:validate
-
-# Test in kind cluster
-task test:create
-task test:install-flux
-task test:apply
-task test:status
-task test:destroy
-```
-
-### Troubleshooting
-
-```bash
-# Remove stuck namespaces
-task k8s:destroy-stuck-ns
-
-# Reset cluster (destroy and rebuild)
-task reset
-task provision
-task bootstrap
-```
+Run `task -l` to list all available tasks.
 
 ---
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -23,7 +23,7 @@ and follow along.
 This project requires:
 
 - **Linux or macOS** - Development environment
-- **SSH access** - To cluster nodes (k8s1-k8s7)
+- **SSH access** - To cluster nodes (k8s1-k8s9 and the Lima VM workers)
 - **1Password CLI** - For secrets management
 
 ---
@@ -60,6 +60,7 @@ brew install pre-commit
 brew install ansible
 brew install terraform
 brew install terragrunt
+brew install --cask 1password-cli
 ```
 
 ### Optional Tools
@@ -67,9 +68,6 @@ brew install terragrunt
 ```bash
 # For local testing
 brew install kind
-
-# For 1Password CLI
-brew install --cask 1password-cli
 ```
 
 ### Python Dependencies
@@ -373,58 +371,9 @@ task destroy-rancher
 
 ## Testing
 
-### Local Testing with kind
-
-See [test-environment.md](test-environment.md) for comprehensive testing documentation.
-
-Quick start:
-
-```bash
-# Validate manifests
-task test:validate
-
-# Create test cluster
-task test:create
-
-# Install Flux
-task test:install-flux
-
-# Apply configurations
-task test:apply
-
-# Check status
-task test:status
-
-# Destroy cluster
-task test:destroy
-```
-
-### Testing Specific Apps
-
-```bash
-# Test single app
-task test:apply-app APP=cert-manager
-
-# Create mock secrets for testing
-task test:mock-secrets
-task test:mock-secrets NAMESPACE=home-automation
-```
-
-### CI/CD Testing
-
-GitHub Actions automatically:
-
-1. Validates manifests on every commit
-2. Tests deployments in kind clusters
-3. Runs pre-commit hooks
-4. Performs security scanning (Semgrep)
-
-View workflow runs:
-
-```bash
-gh run list
-gh run view <run-id>
-```
+Local testing with kind — cluster creation, per-app testing, mock secrets,
+CI/CD integration, and troubleshooting — is covered in
+[test-environment.md](test-environment.md).
 
 ---
 
@@ -463,34 +412,9 @@ task provision-nodes
 
 ---
 
-## Repository Structure
-
-```text
-woe/
-├── .github/              # GitHub Actions workflows
-├── .taskfiles/           # Task definitions (bootstrap, test)
-├── docs/                 # Documentation
-├── infrastructure/       # Terraform/Terragrunt configs
-├── k3s-ansible/          # Ansible k3s provisioning
-│   ├── inventory/        # Cluster inventory (7 nodes)
-│   ├── roles/            # Ansible roles
-│   └── site.yml          # Main playbook
-├── kubernetes/
-│   ├── apps/             # Application manifests (16 namespaces)
-│   ├── bootstrap/        # Bootstrap configuration
-│   │   ├── flux/         # Flux CRDs and components
-│   │   ├── helmfile.d/   # Helmfile configs
-│   │   └── resources.yaml.j2  # Secret templates
-│   └── flux/             # Flux GitOps configs
-├── ansible.cfg           # Ansible configuration
-└── Taskfile.yaml         # Root task definitions
-```
-
----
-
 ## Resources
 
-- [Main README](../README.md)
+- [Main README](../README.md) (includes repository structure)
 - [Test Environment Guide](test-environment.md)
 - [Bootstrap Instructions](../kubernetes/bootstrap/README.md)
 - [Flux Documentation](https://fluxcd.io/flux/)

--- a/hack/readme-gen.sh
+++ b/hack/readme-gen.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Regenerate the marked sections of README.md from repository state.
+#
+# Sections (between "<!-- BEGIN GENERATED: <name> -->" markers):
+#   apps      - applications under kubernetes/apps, grouped by namespace
+#   docs      - guides under docs/
+#   tasks     - root tasks and task categories from Taskfile.yaml
+#   workflows - GitHub Actions workflows
+#
+# Only tracked files (git ls-files) feed the output so local and CI runs
+# agree regardless of untracked files or submodule state. Exits non-zero
+# when README.md changed so pre-commit surfaces the drift.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+README="README.md"
+
+if ! command -v yq > /dev/null 2>&1; then
+    echo "Error: yq is required to regenerate ${README}" >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+# First "# " heading of a markdown file, falling back to its path.
+md_title() {
+    local file="$1" title
+    title="$(awk '/^# / { sub(/^# /, ""); print; exit }' "${file}")"
+    echo "${title:-${file}}"
+}
+
+gen_apps() {
+    local ns app prev_ns="" row_apps="" ns_count=0 app_count=0 table=""
+
+    while IFS=$'\t' read -r ns app; do
+        app_count=$((app_count + 1))
+        if [[ ${ns} != "${prev_ns}" ]]; then
+            if [[ -n ${prev_ns} ]]; then
+                table+="| \`${prev_ns}\` | ${row_apps} |"$'\n'
+            fi
+            ns_count=$((ns_count + 1))
+            prev_ns="${ns}"
+            row_apps=""
+        fi
+        if [[ -n ${row_apps} ]]; then
+            row_apps+=", "
+        fi
+        row_apps+="[${app}](kubernetes/apps/${ns}/${app})"
+    done < <(git ls-files 'kubernetes/apps/*' \
+        | awk -F/ 'NF >= 5 { print $3 "\t" $4 }' \
+        | sort -u)
+    if [[ -n ${prev_ns} ]]; then
+        table+="| \`${prev_ns}\` | ${row_apps} |"$'\n'
+    fi
+
+    echo "Flux reconciles **${app_count} applications** across" \
+        "**${ns_count} namespaces** from [\`kubernetes/apps/\`](kubernetes/apps)."
+    echo ""
+    echo "| Namespace | Applications |"
+    echo "| --------- | ------------ |"
+    printf '%s' "${table}"
+}
+
+gen_docs() {
+    local f
+    while IFS= read -r f; do
+        printf -- '- [%s](%s)\n' "$(md_title "${f}")" "${f}"
+    done < <(git ls-files 'docs/*.md' | sort)
+}
+
+gen_tasks() {
+    local root_tasks name src text url
+    # shellcheck disable=SC2016  # literal backticks, not command substitution
+    root_tasks="$(yq '.tasks | keys | .[]' Taskfile.yaml \
+        | grep -v '^#' \
+        | sed 's/^/`/; s/$/`/' \
+        | paste -s -d ',' - \
+        | sed 's/,/, /g')"
+
+    echo "Root tasks (run as \`task <name>\`): ${root_tasks}." \
+        | fold -s -w 79 \
+        | sed 's/ *$//'
+    echo ""
+    echo "| Category | Defined in |"
+    echo "| -------- | ---------- |"
+    while IFS=$'\t' read -r name src; do
+        if [[ ${src} == https://raw.githubusercontent.com/* ]]; then
+            url="$(echo "${src}" \
+                | sed -E 's|^https://raw\.githubusercontent\.com/([^/]+/[^/]+)/([^/]+)/|https://github.com/\1/blob/\2/|')"
+            text="$(echo "${src}" \
+                | sed -E 's|^https://raw\.githubusercontent\.com/([^/]+/[^/]+)/[^/]+/(.*)/Taskfile\.ya?ml$|\1/\2|')"
+        else
+            url="${src#./}"
+            text="$(dirname "${url}")"
+        fi
+        echo "| \`${name}:*\` | [${text}](${url}) |"
+    done < <(yq '.includes | to_entries | .[]
+        | .key + "\t" + ((.value | select(kind == "map") | .taskfile) // .value)' \
+        Taskfile.yaml | sort)
+}
+
+gen_workflows() {
+    local f name
+    while IFS= read -r f; do
+        name="$(yq '.name // ""' "${f}")"
+        printf -- '- [%s](%s)\n' "${name:-$(basename "${f}")}" "${f}"
+    done < <(git ls-files '.github/workflows/*.y*ml' | sort)
+}
+
+replace_block() {
+    local name="$1" content_file="$2"
+    local begin="<!-- BEGIN GENERATED: ${name} -->"
+    local end="<!-- END GENERATED: ${name} -->"
+    local begin_line end_line
+
+    begin_line="$(grep -nxF "${begin}" "${README}" | head -n1 | cut -d: -f1 || true)"
+    end_line="$(grep -nxF "${end}" "${README}" | head -n1 | cut -d: -f1 || true)"
+    if [[ -z ${begin_line} || -z ${end_line} ]] || ((begin_line >= end_line)); then
+        echo "Error: missing or malformed markers for section '${name}' in ${README}" >&2
+        exit 1
+    fi
+
+    {
+        head -n "${begin_line}" "${README}"
+        echo ""
+        cat "${content_file}"
+        echo ""
+        tail -n +"${end_line}" "${README}"
+    } > "${TMP_DIR}/readme"
+    mv "${TMP_DIR}/readme" "${README}"
+}
+
+main() {
+    local before="${TMP_DIR}/before" section
+    cp "${README}" "${before}"
+
+    for section in apps docs tasks workflows; do
+        "gen_${section}" > "${TMP_DIR}/${section}.md"
+        replace_block "${section}" "${TMP_DIR}/${section}.md"
+    done
+
+    if ! cmp -s "${before}" "${README}"; then
+        echo "Regenerated sections in ${README}; review and re-stage it."
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
**Key Changes:**

- Added a README section generator (`hack/readme-gen.sh`) that regenerates apps, docs, tasks, and workflows sections from tracked repository state
- Condensed the README by delegating detailed prerequisites, usage, and repository structure to the Developer Guide
- Consolidated testing and repository structure documentation into single canonical locations to reduce duplication

**Added:**

- README section generator - Created `hack/readme-gen.sh`, a Bash script that regenerates marked sections (apps grouped by namespace, docs guides, root tasks and categories, and GitHub Actions workflows) using only `git ls-files` tracked files so local and CI runs stay consistent; exits non-zero on drift for pre-commit integration
- 1Password CLI install step - Added `brew install --cask 1password-cli` to the required tools list in `docs/dev.md`

**Changed:**

- Prerequisites section in `README.md` - Replaced the verbose tool list and macOS/Linux quick-install blocks with a concise summary pointing to the Developer Guide
- Usage section in `README.md` - Replaced detailed cluster management, GitOps, Flux, development, and troubleshooting command blocks with references to the Developer Guide and Test Environment guide, plus a `task -l` pointer
- Markdown lint config - Enforced an 80-character line length via `MD013` in `.hooks/linters/markdownlint.json` (previously disabled)
- SSH access prerequisite in `docs/dev.md` - Updated node range to `k8s1-k8s9` and noted the Lima VM workers
- Resources list in `docs/dev.md` - Noted that the main README now includes repository structure

**Removed:**

- Local testing and CI/CD sections in `docs/dev.md` - Removed duplicated kind testing, per-app testing, mock secrets, and CI/CD command blocks in favor of a reference to `test-environment.md`
- Repository structure diagram in `docs/dev.md` - Removed the directory tree, now maintained in the main README
- Duplicate 1Password CLI install - Removed `brew install --cask 1password-cli` from the optional tools section in `docs/dev.md`