### PR TITLE
docs: document frigate alerting and update zone trade-offs

### DIFF
--- a/kubernetes/apps/home-automation/frigate/README.md
+++ b/kubernetes/apps/home-automation/frigate/README.md
@@ -207,6 +207,43 @@ pin the image tag rather than tracking `stable-rk`.
 DNS comes from external-dns. The zone is publicly resolvable but points at
 RFC1918 addresses, so remote access requires the UDM Pro VPN.
 
+## Alerting
+
+Frigate detects; Home Assistant notifies. The two are coupled only by MQTT
+topics, so the Frigate HACS integration is not installed and not required.
+
+### Person at the basement door
+
+- Frigate: `living_room.zones.basement_door`, filtered to `person`
+- Topic: `frigate/basement_door/person`, an occupancy count
+- Fires on any non-zero count, then holds two minutes
+
+### Crying heard
+
+- Frigate: `living_room.audio.listen: [crying]`
+- Topic: `frigate/living_room/audio/crying`, `ON` / `OFF`
+- Fires on `ON`, then holds five minutes
+
+The automations live in
+[CowDogMoo/homeassistant](https://github.com/CowDogMoo/homeassistant) at
+`automation/frigate_alerts.yaml`, not in this repo.
+
+Zone occupancy topics are keyed by **zone name, not camera** —
+`activity_manager` publishes `frigate/<zone>/<label>`. Zone names must stay
+unique across all cameras or two cameras will collide on one topic.
+
+Audio detection needs the `audio` role on an input whose stream actually
+carries audio. All the wired cameras do (G.711); the Nest cameras are not
+restreamed through go2rtc and cannot serve it. Frigate has no audio-only
+camera — `config/camera/ffmpeg.py` rejects any camera lacking a `detect`
+role — so hearing a room requires a video source in it.
+
+Tuning: Frigate only runs the audio model when the stream clears
+`audio.min_volume` (default 500 RMS; an idle living room reads about 8). Watch
+`frigate/living_room/audio/rms` during a real event and lower `min_volume` if
+detections are being missed. Per-label confidence lives in
+`audio.filters.<label>.threshold`.
+
 ## Known trade-offs
 
 - `config.yml` is mounted read-only from a Secret, so 1Password stays the source
@@ -216,7 +253,8 @@ RFC1918 addresses, so remote access requires the UDM Pro VPN.
 - Config changes are invisible to `git diff` and to PR review — the repo holds
   only the ExternalSecret wrapper. That is the deliberate trade for keeping
   camera names, addresses, and stream paths out of a public repo.
-- No zones are defined yet. Alert quality depends almost entirely on them.
+- `basement_door` on `living_room` is the only zone. Every other camera still
+  alerts on any tracked object anywhere in frame.
 - `strategy: Recreate` is required. Two pods against one SQLite database
   corrupts it.
 - `archiveOnDelete: "true"` on `nfs-client` means deleting the media PVC renames


### PR DESCRIPTION
**Key Changes:**

- Added a comprehensive Alerting section explaining how Frigate detection and Home Assistant notifications are coupled via MQTT topics
- Documented person and audio (crying) detection setups with their MQTT topics and hold behavior
- Updated the known trade-offs to reflect the current single-zone configuration

**Added:**

- Alerting documentation - Added an Alerting section to `README.md` describing the Frigate-to-Home-Assistant notification flow, clarifying that the Frigate HACS integration is neither installed nor required since coupling happens only through MQTT topics
- Detection examples - Documented the "person at the basement door" and "crying heard" alerts, including their Frigate config sources, MQTT topics, and hold durations, with a note that the automations live in the external CowDogMoo/homeassistant repo
- Topic and audio caveats - Explained that zone occupancy topics are keyed by zone name (not camera) and must stay unique to avoid collisions, and detailed audio detection requirements (the `audio` role on a video stream carrying audio, G.711 wired cameras vs. non-restreamed Nest cameras)
- Audio tuning guidance - Added tuning notes covering `audio.min_volume` thresholds, monitoring the RMS topic during events, and per-label confidence via `audio.filters.<label>.threshold`

**Changed:**

- Zone trade-off note - Updated the known trade-offs in `README.md` to state that `basement_door` on `living_room` is the only defined zone, replacing the prior note that no zones existed, and clarified that all other cameras still alert on any tracked object anywhere in frame