### PR TITLE
docs: update frigate ring doorbell integration notes

### DIFF
--- a/kubernetes/apps/home-automation/frigate/README.md
+++ b/kubernetes/apps/home-automation/frigate/README.md
@@ -151,14 +151,16 @@ servers, so the bandwidth gets spent twice. Streams drop and re-dial on
 their own schedule. And revoking the Google OAuth grant takes out the
 cameras in HA and Frigate at the same time.
 
-The Ring doorbell is not a Frigate camera. It runs on battery, and
-Frigate decodes every configured camera continuously, which would flatten
-that battery; Ring terminates long-lived sessions anyway. It is instead a
-pair of on-demand go2rtc-only streams, `front_door` and
-`front_door_snapshot`, that dial Ring's cloud only while a client is
-actually watching: `rtsp://192.168.20.18:8554/front_door`, or WebRTC on
-`192.168.20.18:8555`. They do not appear in the Frigate camera UI, and
-should not.
+The Ring doorbell gets a Frigate tile without the battery cost. Frigate
+decodes every configured camera continuously, which would flatten the
+doorbell battery, so the `front_door` camera's decode input is a locally
+generated lavfi placeholder card (it needs `/config/placeholder-font.ttf`
+on the PVC, currently Arial Bold), with detect, record, and snapshots all
+off. Its live view maps to the on-demand go2rtc `ring:` stream instead:
+opening the camera dials Ring's cloud, closing it hangs up, the same
+idle-until-viewed behavior as the HA card. The streams are also reachable
+directly at `rtsp://192.168.20.18:8554/front_door` (plus
+`front_door_snapshot`), or WebRTC on `192.168.20.18:8555`.
 
 The `ring:` source needs go2rtc ≥ 1.9.13, which the patched `/config`
 binary provides. Its refresh token has to be separate from Home


### PR DESCRIPTION
**Key Changes:**

- Documented new approach for integrating the Ring doorbell as a Frigate tile without incurring battery cost
- Clarified the use of a lavfi placeholder card for the `front_door` camera decode input
- Explained the on-demand go2rtc stream behavior for live viewing

**Changed:**

- Ring doorbell documentation - Rewrote the Frigate README section to describe the doorbell now appearing as a Frigate tile, using a locally generated lavfi placeholder card (requiring `/config/placeholder-font.ttf` on the PVC) for decode input while keeping detect, record, and snapshots off to avoid draining the battery
- Live view behavior - Clarified that the camera's live view maps to the on-demand go2rtc `ring:` stream, dialing Ring's cloud only while actively viewed and hanging up on close, mirroring the HA card's idle-until-viewed behavior
- Stream access details - Retained direct stream access notes for `front_door` and `front_door_snapshot` via RTSP (`rtsp://192.168.20.18:8554/front_door`) and WebRTC (`192.168.20.18:8555`)