### PR TITLE
fix: pin music-assistant image and add authentik middleware

### DIFF
--- a/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           app:
             image:
               repository: ghcr.io/music-assistant/server
-              tag: latest
+              tag: 2.9.11
             env:
               TZ: "America/Denver"
               LOG_LEVEL: "info" # options: critical, error, warning, info, debug
@@ -87,6 +87,7 @@ spec:
         className: ingress-traefik
         annotations:
           external-dns.alpha.kubernetes.io/hostname: music.techvomit.xyz
+          traefik.ingress.kubernetes.io/router.middlewares: networking-authentik@kubernetescrd
         hosts:
           - host: &host music.techvomit.xyz
             paths:


### PR DESCRIPTION
**Key Changes:**

- Pinned the music-assistant server image to a specific version instead of using the mutable `latest` tag
- Added Authentik authentication middleware to the ingress configuration

**Changed:**

- Music-assistant image versioning - Replaced the `latest` tag with the pinned version `2.9.11` in `helmrelease.yaml` to ensure reproducible and stable deployments
- Ingress authentication - Added the `traefik.ingress.kubernetes.io/router.middlewares` annotation referencing `networking-authentik@kubernetescrd` in `helmrelease.yaml` to route traffic through Authentik for authentication