### PR TITLE
feat: add Music Assistant forward auth integration to Authentik

### DIFF
--- a/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
+++ b/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
@@ -145,6 +145,14 @@ data:
         attrs:
           name: Frigate Users
 
+      - model: authentik_core.group
+        id: music-assistant-users
+        identifiers:
+          name: Music Assistant Users
+        state: present
+        attrs:
+          name: Music Assistant Users
+
       # Custom Scope Mapping for Home Assistant groups and admin status
       - model: authentik_providers_oauth2.scopemapping
         id: homeassistant-groups-scope
@@ -283,6 +291,25 @@ data:
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           mode: forward_single
           external_host: "https://frigate.techvomit.xyz"
+          cookie_domain: "techvomit.xyz"
+          skip_path_regex: ""
+          basic_auth_enabled: false
+          intercept_header_auth: true
+          access_token_validity: "minutes=5"
+          refresh_token_validity: "days=30"
+
+      # Proxy Provider for Music Assistant (Forward Auth)
+      - model: authentik_providers_proxy.proxyprovider
+        id: music-assistant-provider
+        identifiers:
+          name: Music Assistant
+        state: present
+        attrs:
+          name: Music Assistant
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: forward_single
+          external_host: "https://music.techvomit.xyz"
           cookie_domain: "techvomit.xyz"
           skip_path_regex: ""
           basic_auth_enabled: false
@@ -587,6 +614,20 @@ data:
           meta_description: "Frigate NVR - Camera Monitoring and Recording"
           policy_engine_mode: any
 
+      # Application for Music Assistant
+      - model: authentik_core.application
+        id: music-assistant-app
+        identifiers:
+          slug: music-assistant
+        state: present
+        attrs:
+          name: Music Assistant
+          slug: music-assistant
+          provider: !KeyOf music-assistant-provider
+          meta_launch_url: "https://music.techvomit.xyz"
+          meta_description: "Music Assistant - Multi-room Audio Server"
+          policy_engine_mode: any
+
       # Expression policy for group checking
       - model: authentik_policies_expression.expressionpolicy
         id: traefik-admin-policy
@@ -687,6 +728,16 @@ data:
           name: frigate-user-policy
           expression: |
             return ak_is_group_member(request.user, name="Frigate Users")
+
+      - model: authentik_policies_expression.expressionpolicy
+        id: music-assistant-user-policy
+        identifiers:
+          name: music-assistant-user-policy
+        state: present
+        attrs:
+          name: music-assistant-user-policy
+          expression: |
+            return ak_is_group_member(request.user, name="Music Assistant Users")
 
       # Policy binding for Traefik application
       - model: authentik_policies.policybinding
@@ -798,6 +849,17 @@ data:
           enabled: true
           order: 0
 
+      # Policy binding for Music Assistant application
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf music-assistant-app
+          policy: !KeyOf music-assistant-user-policy
+          order: 0
+        state: present
+        attrs:
+          enabled: true
+          order: 0
+
       # Assign provider to embedded outpost
       - model: authentik_outposts.outpost
         identifiers:
@@ -808,3 +870,4 @@ data:
             - !KeyOf guacamole-provider
             - !KeyOf adguard-provider
             - !KeyOf frigate-provider
+            - !KeyOf music-assistant-provider


### PR DESCRIPTION
**Key Changes:**

- Added complete Authentik configuration for Music Assistant with forward auth proxy provider
- Introduced group-based access control restricting access to "Music Assistant Users"
- Registered the Music Assistant provider with the embedded outpost for authentication enforcement

**Added:**

- Music Assistant user group - Created the "Music Assistant Users" group (`music-assistant-users`) to manage access control for the application
- Forward auth proxy provider - Added `music-assistant-provider` in forward_single mode targeting `https://music.techvomit.xyz` with the `techvomit.xyz` cookie domain, header auth interception, and 5-minute access / 30-day refresh token validity
- Music Assistant application - Registered the `music-assistant-app` with slug `music-assistant`, linked to its proxy provider and launch URL for the app catalog
- Access control policy and binding - Added the `music-assistant-user-policy` expression policy checking group membership and bound it to the application to restrict access to authorized users
- Outpost provider assignment - Registered `music-assistant-provider` with the embedded outpost so forward auth is enforced at the proxy layer