### PR TITLE
feat: add Music Assistant forward auth provider and application

### DIFF
--- a/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
+++ b/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
@@ -290,6 +290,25 @@ data:
           access_token_validity: "minutes=5"
           refresh_token_validity: "days=30"
 
+      # Proxy Provider for Music Assistant (Forward Auth)
+      - model: authentik_providers_proxy.proxyprovider
+        id: music-assistant-provider
+        identifiers:
+          name: Music Assistant
+        state: present
+        attrs:
+          name: Music Assistant
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: forward_single
+          external_host: "https://music.techvomit.xyz"
+          cookie_domain: "techvomit.xyz"
+          skip_path_regex: ""
+          basic_auth_enabled: false
+          intercept_header_auth: true
+          access_token_validity: "minutes=5"
+          refresh_token_validity: "days=30"
+
       # OAuth2 Provider for Tailscale
       - model: authentik_providers_oauth2.oauth2provider
         id: tailscale-provider
@@ -587,6 +606,21 @@ data:
           meta_description: "Frigate NVR - Camera Monitoring and Recording"
           policy_engine_mode: any
 
+      # Application for Music Assistant. No policy binding on purpose: any
+      # authenticated user may access it (household-wide music control).
+      - model: authentik_core.application
+        id: music-assistant-app
+        identifiers:
+          slug: music-assistant
+        state: present
+        attrs:
+          name: Music Assistant
+          slug: music-assistant
+          provider: !KeyOf music-assistant-provider
+          meta_launch_url: "https://music.techvomit.xyz"
+          meta_description: "Music Assistant - Whole Home Audio"
+          policy_engine_mode: any
+
       # Expression policy for group checking
       - model: authentik_policies_expression.expressionpolicy
         id: traefik-admin-policy
@@ -808,3 +842,4 @@ data:
             - !KeyOf guacamole-provider
             - !KeyOf adguard-provider
             - !KeyOf frigate-provider
+            - !KeyOf music-assistant-provider


### PR DESCRIPTION
**Key Changes:**

- Added a forward auth proxy provider for Music Assistant to enable authenticated access
- Created a corresponding Authentik application accessible to any authenticated user for household-wide music control
- Registered the new provider with the embedded outpost

**Added:**

- Music Assistant proxy provider - Added a `forward_single` mode proxy provider in `authentik-oauth-blueprint.yaml` with external host `music.techvomit.xyz`, cookie domain `techvomit.xyz`, header auth interception, and 5-minute access / 30-day refresh token validity
- Music Assistant application - Added an Authentik core application bound to the new provider with launch URL `music.techvomit.xyz`, using `any` policy engine mode and intentionally no policy binding so any authenticated user can access it for whole-home audio control

**Changed:**

- Outpost provider registration - Registered the new `music-assistant-provider` in the embedded outpost provider list alongside existing providers in `authentik-oauth-blueprint.yaml`