### PR TITLE
fix: increase music-assistant memory limit and pin to arm64 nodes

### DIFF
--- a/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
                 cpu: 100m
                 memory: 256Mi
               limits:
-                memory: 1Gi
+                memory: 4Gi # Smart Fades provider requires 4GB detected via cgroup limit
             securityContext:
               privileged: true # Required for network discovery
               capabilities:
@@ -70,6 +70,8 @@ spec:
         pod:
           hostNetwork: true # Required for Music Assistant to discover Sonos speakers
           dnsPolicy: ClusterFirstWithHostNet
+          nodeSelector:
+            kubernetes.io/arch: arm64 # k8s8's virtual CPU lacks x86-64-v2, which Music Assistant requires
           securityContext:
             fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
**Key Changes:**

- Raised Music Assistant container memory limit from 1Gi to 4Gi to satisfy the Smart Fades provider's cgroup-detected memory requirement
- Added an arm64 node selector to avoid scheduling on k8s8, whose virtual CPU lacks x86-64-v2 support required by Music Assistant

**Changed:**

- Memory limit for the Music Assistant container - Increased from 1Gi to 4Gi in `kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml` to meet the Smart Fades provider's runtime requirement
- Pod scheduling constraints - Added `kubernetes.io/arch: arm64` nodeSelector to ensure the workload only lands on arm64 nodes, since k8s8's virtualized CPU lacks the x86-64-v2 instruction set Music Assistant depends on
