### PR TITLE
fix: exclude music-assistant from serpent node

### DIFF
--- a/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml
@@ -70,8 +70,19 @@ spec:
         pod:
           hostNetwork: true # Required for Music Assistant to discover Sonos speakers
           dnsPolicy: ClusterFirstWithHostNet
-          nodeSelector:
-            kubernetes.io/arch: arm64 # k8s8's virtual CPU lacks x86-64-v2, which Music Assistant requires
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                          - arm64
+                      - key: kubernetes.io/hostname
+                        operator: NotIn
+                        values:
+                          - serpent # Lima VM bridge drops multicast discovery and streaming when socket_vmnet flaps
           securityContext:
             fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
**Key Changes:**

- Replaced simple arm64 nodeSelector with a nodeAffinity rule that both requires arm64 and excludes the serpent node
- Prevents Music Assistant from being scheduled onto the serpent Lima VM, where socket_vmnet bridge flaps break multicast discovery and streaming

**Changed:**

- Music Assistant scheduling constraints - `kubernetes/apps/home-automation/music-assistant/app/helmrelease.yaml` now uses `requiredDuringSchedulingIgnoredDuringExecution` node affinity combining an arm64 architecture requirement with a `NotIn` exclusion for the serpent hostname, replacing the prior `nodeSelector` block