### PR TITLE
feat: add serve-static task for ephemeral local HTML hosting

### DIFF
--- a/.taskfiles/serve-static/Taskfile.yaml
+++ b/.taskfiles/serve-static/Taskfile.yaml
@@ -1,0 +1,79 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+set: [pipefail]
+
+vars:
+  SERVE_STATIC_SCRIPT: "{{.ROOT_DIR}}/hack/serve-static.sh"
+
+tasks:
+  up:
+    desc: Serve a local HTML file on the cluster as an ephemeral site
+    summary: |
+      Publishes a local HTML file at https://<HOST> using the serve-static
+      template. The content never enters git — it lives in a ConfigMap inside
+      a throwaway namespace labeled serve-static/ephemeral=true.
+
+      Required Parameters:
+        NAME - Namespace/deployment name (e.g., "gift-board")
+        FILE - Path to the local HTML file to serve
+
+      Optional Parameters:
+        HOST - Hostname to serve on (defaults to <NAME>.techvomit.xyz,
+               which is covered by the wildcard cert)
+
+      Usage:
+        task serve-static:up NAME=gift-board FILE=~/Downloads/gift-board.html
+        task serve-static:up NAME=demo FILE=./demo.html HOST=demo.techvomit.xyz
+    vars:
+      NAME: '{{.NAME | default ""}}'
+      FILE: '{{.FILE | default ""}}'
+      HOST: '{{.HOST | default (printf "%s.techvomit.xyz" .NAME)}}'
+    cmds:
+      - |
+        if [ -z "{{.NAME}}" ] || [ -z "{{.FILE}}" ]; then
+          echo "Error: NAME and FILE are required"
+          echo ""
+          echo "Usage: task serve-static:up NAME=gift-board FILE=~/Downloads/gift-board.html"
+          echo "       task serve-static:up NAME=demo FILE=./demo.html HOST=demo.techvomit.xyz"
+          exit 1
+        fi
+
+        # expand a leading ~ that the invoking shell may have left literal
+        file="{{.FILE}}"
+        file="${file/#\~/$HOME}"
+
+        "{{.SERVE_STATIC_SCRIPT}}" up "{{.NAME}}" "$file" "{{.HOST}}"
+    silent: true
+
+  down:
+    desc: Tear down an ephemeral serve-static site
+    summary: |
+      Deletes the namespace created by serve-static:up. Refuses to delete
+      namespaces that were not created by serve-static.
+
+      Required Parameters:
+        NAME - Namespace name used at creation time
+
+      Usage:
+        task serve-static:down NAME=gift-board
+    vars:
+      NAME: '{{.NAME | default ""}}'
+    cmds:
+      - |
+        if [ -z "{{.NAME}}" ]; then
+          echo "Error: NAME is required"
+          echo ""
+          echo "Usage: task serve-static:down NAME=gift-board"
+          exit 1
+        fi
+
+        "{{.SERVE_STATIC_SCRIPT}}" down "{{.NAME}}"
+    silent: true
+
+  list:
+    desc: List all ephemeral serve-static sites
+    cmds:
+      - '"{{.SERVE_STATIC_SCRIPT}}" list'
+    silent: true

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Root tasks (run as `task <name>`): `default`, `check-inventory`,
 | `pre-commit:*` | [CowDogMoo/taskfile-templates/pre-commit](https://github.com/CowDogMoo/taskfile-templates/blob/main/pre-commit/Taskfile.yaml) |
 | `proxmox:*` | [.taskfiles/proxmox](.taskfiles/proxmox/Taskfile.yaml) |
 | `renovate:*` | [CowDogMoo/taskfile-templates/renovate](https://github.com/CowDogMoo/taskfile-templates/blob/main/renovate/Taskfile.yaml) |
+| `serve-static:*` | [.taskfiles/serve-static](.taskfiles/serve-static/Taskfile.yaml) |
 | `terraform:*` | [CowDogMoo/taskfile-templates/terraform](https://github.com/CowDogMoo/taskfile-templates/blob/main/terraform/Taskfile.yaml) |
 | `test:*` | [.taskfiles/test](.taskfiles/test/Taskfile.yaml) |
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,6 +15,7 @@ includes:
   test: ./.taskfiles/test/Taskfile.yaml
   guacamole: ./.taskfiles/guacamole/Taskfile.yaml
   proxmox: ./.taskfiles/proxmox/Taskfile.yaml
+  serve-static: ./.taskfiles/serve-static/Taskfile.yaml
 
 vars:
   INVENTORY: "k3s-ansible/inventory/cowdogmoo/hosts.ini"

--- a/hack/serve-static.sh
+++ b/hack/serve-static.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# serve-static.sh — put an arbitrary local HTML file on the cluster, briefly.
+#
+#   ./serve-static.sh up   gift-board ~/Downloads/gift-board.html gift-board.techvomit.xyz
+#   ./serve-static.sh down gift-board
+#   ./serve-static.sh list
+#
+# The content never enters git. Only this script and the template do.
+set -euo pipefail
+
+TEMPLATE="${TEMPLATE:-$(dirname "$0")/static-site.tmpl.yaml}"
+# Wildcard *.techvomit.xyz cert, auto-reflected into new namespaces by reflector.
+TLS_SECRET="${TLS_SECRET:-techvomit-xyz-production-tls}"
+
+usage() {
+    sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+up() {
+    local name="$1" file="$2" host="$3"
+    [[ -f "$file" ]] || {
+        echo "no such file: $file" >&2
+        exit 1
+    }
+    [[ "$host" == *.techvomit.xyz ]] \
+        || echo "warning: ${host} is not covered by the ${TLS_SECRET} wildcard cert" >&2
+
+    export NAME="$name" HOST="$host" TLS_SECRET
+    export CONTENT_HASH
+    CONTENT_HASH="$(sha256sum "$file" | cut -c1-16)"
+
+    # namespace + workload first, so the ConfigMap has somewhere to land
+    # shellcheck disable=SC2016  # literal list tells envsubst which vars to touch
+    envsubst '${NAME} ${HOST} ${TLS_SECRET} ${CONTENT_HASH}' < "$TEMPLATE" \
+        | kubectl apply -f -
+
+    # server-side apply: content can exceed the 256KB last-applied-configuration
+    # annotation cap that client-side apply hits on large files
+    kubectl -n "$name" create configmap "${name}-content" \
+        --from-file=index.html="$file" \
+        --dry-run=client -o yaml \
+        | kubectl apply --server-side --force-conflicts -f -
+
+    kubectl -n "$name" rollout restart deploy/"$name" > /dev/null
+    kubectl -n "$name" rollout status deploy/"$name" --timeout=90s
+
+    echo
+    echo "  https://${host}"
+    echo "  tear down:  $0 down ${name}"
+}
+
+down() {
+    local name="$1"
+    kubectl get ns "$name" -o jsonpath='{.metadata.labels.serve-static/ephemeral}' 2> /dev/null \
+        | grep -q true || {
+        echo "'$name' isn't a serve-static namespace — refusing" >&2
+        exit 1
+    }
+    kubectl delete ns "$name" --wait=false
+    echo "deleting namespace ${name}"
+}
+
+list() {
+    kubectl get ns -l serve-static/ephemeral=true \
+        -o custom-columns=NAME:.metadata.name,AGE:.metadata.creationTimestamp
+}
+
+case "${1:-}" in
+    up)
+        [[ $# -eq 4 ]] || usage
+        up "$2" "$3" "$4"
+        ;;
+    down)
+        [[ $# -eq 2 ]] || usage
+        down "$2"
+        ;;
+    list) list ;;
+    *) usage ;;
+esac

--- a/hack/static-site.tmpl.yaml
+++ b/hack/static-site.tmpl.yaml
@@ -1,0 +1,87 @@
+# Generic ephemeral static-page host.
+# Nothing app-specific lives here — content is injected at apply time
+# from a local file via `serve-static.sh`.
+#
+# Substituted: ${NAME} ${HOST} ${TLS_SECRET} ${CONTENT_HASH}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAME}
+  labels:
+    app.kubernetes.io/managed-by: serve-static
+    serve-static/ephemeral: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${NAME}
+  namespace: ${NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: "${NAME}" }
+  template:
+    metadata:
+      labels: { app: "${NAME}" }
+      annotations:
+        # rolls the pod whenever the content hash changes
+        serve-static/content-hash: "${CONTENT_HASH}"
+    spec:
+      containers:
+        - name: nginx
+          # unprivileged variant: runs non-root on 8080, works with all caps dropped
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports: [{ containerPort: 8080 }]
+          volumeMounts:
+            - {
+                name: content,
+                mountPath: /usr/share/nginx/html,
+                readOnly: true,
+              }
+            - { name: tmp, mountPath: /tmp }
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { memory: 64Mi }
+          readinessProbe:
+            httpGet: { path: /, port: 8080 }
+            initialDelaySeconds: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities: { drop: ["ALL"] }
+      volumes:
+        - name: content
+          configMap:
+            name: ${NAME}-content
+        - { name: tmp, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${NAME}
+  namespace: ${NAME}
+spec:
+  selector: { app: "${NAME}" }
+  ports: [{ port: 80, targetPort: 8080 }]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${NAME}
+  namespace: ${NAME}
+spec:
+  ingressClassName: ingress-traefik
+  rules:
+    - host: ${HOST}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ${NAME}
+                port: { number: 80 }
+  tls:
+    - hosts: ["${HOST}"]
+      secretName: ${TLS_SECRET}


### PR DESCRIPTION
**Key Changes:**

- Introduced a `serve-static` Task namespace that publishes a local HTML file on the cluster as a throwaway ephemeral site without committing content to git
- Added a shell helper and Kubernetes template that provision a namespace, ConfigMap, Deployment, Service, and Ingress from a single local file, wired to the wildcard `*.techvomit.xyz` TLS cert
- Wired the new Task namespace into the root Taskfile and README task-namespace index

**Added:**

- `serve-static:up`, `serve-static:down`, and `serve-static:list` tasks with parameter validation, tilde expansion, and usage help - `.taskfiles/serve-static/Taskfile.yaml`
- `hack/serve-static.sh` helper that renders the template with `envsubst`, uses server-side apply for the content ConfigMap to bypass the 256KB last-applied-configuration cap, rolls the deployment on content-hash change, and refuses to `down` namespaces it did not create (guarded by the `serve-static/ephemeral=true` label)
- `hack/static-site.tmpl.yaml` generic template running `nginx-unprivileged` as non-root on port 8080 with dropped capabilities, readiness probe, resource limits, and Traefik ingress with TLS

**Changed:**

- Root `Taskfile.yaml` now includes the `serve-static` namespace
- README task-namespace table lists the new `serve-static:*` entry