### PR TITLE
fix: remove stale attack-simulation test references

### DIFF
--- a/.github/workflows/test-manifests.yaml
+++ b/.github/workflows/test-manifests.yaml
@@ -135,14 +135,14 @@ jobs:
 
           echo ""
           echo "🚀 Checking testable pods..."
-          kubectl get pods -A | grep -E "external-secrets|nfs-subdir|reflector|atomic|ttpforge|system-upgrade" || true
+          kubectl get pods -A | grep -E "external-secrets|nfs-subdir|reflector|system-upgrade" || true
 
           echo ""
           echo "✅ Verifying critical deployments..."
           FAILED=0
 
           # Check that core apps deployed successfully (excluding nfs-subdir which requires external NFS server)
-          for app in "external-secrets:external-secrets" "kube-system:reflector" "attack-simulation:atomic-red-team" "attack-simulation:ttpforge" "system-upgrade:system-upgrade-controller"; do
+          for app in "external-secrets:external-secrets" "kube-system:reflector" "system-upgrade:system-upgrade-controller"; do
             namespace=$(echo $app | cut -d: -f1)
             name=$(echo $app | cut -d: -f2)
 

--- a/.taskfiles/test/Taskfile.yaml
+++ b/.taskfiles/test/Taskfile.yaml
@@ -189,8 +189,6 @@ tasks:
           "kube-system/reloader/app"
           "flux-system/flux-operator/app"
           "flux-system/flux-instance/app"
-          "attack-simulation/atomic-red-team/app"
-          "attack-simulation/ttpforge/app"
           "system-upgrade/system-upgrade-controller/app"
         )
 
@@ -394,8 +392,6 @@ tasks:
           "kube-system/reloader/app"
           "flux-system/flux-operator/app"
           "flux-system/flux-instance/app"
-          "attack-simulation/atomic-red-team/app"
-          "attack-simulation/ttpforge/app"
           "system-upgrade/system-upgrade-controller/app"
         )
 


### PR DESCRIPTION
**Key Changes:**

- Removed references to decommissioned `attack-simulation` namespace apps (atomic-red-team, ttpforge) from CI and test tooling
- Aligned pod check and deployment verification in the manifest test workflow with the currently deployed app set
- Cleaned up test Taskfile helm-release lists to match the actual cluster state

**Removed:**

- Attack-simulation deployment checks - Dropped `attack-simulation:atomic-red-team` and `attack-simulation:ttpforge` from the critical deployment verification loop and pod grep filter in `.github/workflows/test-manifests.yaml`
- Attack-simulation helm releases - Removed `attack-simulation/atomic-red-team/app` and `attack-simulation/ttpforge/app` entries from both helm-release lists in `.taskfiles/test/Taskfile.yaml`