### PR TITLE
fix: pin hass-oidc-auth to release zip and restore password auth flow

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -54,21 +54,26 @@ spec:
             image:
               repository: alpine/git
               tag: latest
+            env:
+              # renovate: datasource=github-releases depName=christiaangoossens/hass-oidc-auth
+              OIDC_VERSION: "v1.1.1"
             command:
               - sh
               - -c
               - |
-                echo "$(date): Installing hass-oidc-auth custom component"
+                echo "$(date): Installing hass-oidc-auth ${OIDC_VERSION}"
 
-                # Clone the repository
+                # The release zip ships the built static assets (style.css); the git
+                # tree does not, so install from the release artifact, never a clone.
                 cd /tmp
-                git clone --depth 1 https://github.com/christiaangoossens/hass-oidc-auth.git
+                wget -q "https://github.com/christiaangoossens/hass-oidc-auth/releases/download/${OIDC_VERSION}/hass-oidc-auth.zip"
 
-                # Create custom_components directory and copy files
                 mkdir -p /config/custom_components
-                cp -r /tmp/hass-oidc-auth/custom_components/auth_oidc /config/custom_components/
+                rm -rf /config/custom_components/auth_oidc
+                mkdir -p /config/custom_components/auth_oidc
+                unzip -q hass-oidc-auth.zip -d /config/custom_components/auth_oidc
 
-                echo "$(date): OIDC component installed successfully"
+                echo "$(date): OIDC component ${OIDC_VERSION} installed successfully"
                 ls -la /config/custom_components/auth_oidc/
           setup-ts:
             image:

--- a/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
+++ b/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
@@ -383,7 +383,9 @@ data:
           client_id: home-assistant
           client_secret: !Context homeassistant_client_secret
           client_type: confidential
-          authentication_flow: !Find [authentik_flows.flow, [slug, passwordless-webauthn]]
+          # Shared with password-only users (amanda) — the passwordless flow has no
+          # password fallback and dead-ends anyone without a passkey.
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Internal JWT Certificate]]
@@ -438,7 +440,9 @@ data:
           client_id: immich
           client_secret: !Context immich_client_secret
           client_type: confidential
-          authentication_flow: !Find [authentik_flows.flow, [slug, passwordless-webauthn]]
+          # Shared with password-only users (amanda) — the passwordless flow has no
+          # password fallback and dead-ends anyone without a passkey.
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Internal JWT Certificate]]


### PR DESCRIPTION
**Key Changes:**

- Pinned hass-oidc-auth to release zip artifact instead of git clone to include prebuilt static assets
- Switched Home Assistant and Immich OAuth providers from passwordless-webauthn to default-authentication-flow to unblock password-only users
- Introduced Renovate-tracked version pin for the OIDC component

**Changed:**

- hass-oidc-auth installation now downloads the versioned release zip (`v1.1.1`) via wget and unzips into `custom_components/auth_oidc`, replacing the shallow git clone that omitted built assets like `style.css` - `kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml`
- Home Assistant OAuth provider authentication_flow switched to `default-authentication-flow` so password-only users (amanda) can authenticate instead of dead-ending on a passkey-only flow - `kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml`
- Immich OAuth provider authentication_flow switched to `default-authentication-flow` for the same password-fallback reason - `kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml`