### PR TITLE
feat: add mealie recipe manager with authentik SSO and nightly sqlite backups

### DIFF
--- a/.taskfiles/test/Taskfile.yaml
+++ b/.taskfiles/test/Taskfile.yaml
@@ -190,6 +190,7 @@ tasks:
           "flux-system/flux-operator/app"
           "flux-system/flux-instance/app"
           "system-upgrade/system-upgrade-controller/app"
+          "home-automation/mealie/app"
         )
 
         for app_path in "${TESTABLE_APPS[@]}"; do
@@ -393,6 +394,7 @@ tasks:
           "flux-system/flux-operator/app"
           "flux-system/flux-instance/app"
           "system-upgrade/system-upgrade-controller/app"
+          "home-automation/mealie/app"
         )
 
         for app_path in "${TESTABLE_APPS[@]}"; do

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ woe/
 
 <!-- BEGIN GENERATED: apps -->
 
-Flux reconciles **45 applications** across **17 namespaces** from [`kubernetes/apps/`](kubernetes/apps).
+Flux reconciles **46 applications** across **17 namespaces** from [`kubernetes/apps/`](kubernetes/apps).
 
 | Namespace | Applications |
 | --------- | ------------ |
@@ -231,7 +231,7 @@ Flux reconciles **45 applications** across **17 namespaces** from [`kubernetes/a
 | `external-secrets` | [external-secrets](kubernetes/apps/external-secrets/external-secrets), [onepassword](kubernetes/apps/external-secrets/onepassword) |
 | `flux-system` | [addons](kubernetes/apps/flux-system/addons), [flux-instance](kubernetes/apps/flux-system/flux-instance), [flux-operator](kubernetes/apps/flux-system/flux-operator), [weave-gitops](kubernetes/apps/flux-system/weave-gitops) |
 | `guacamole` | [guacamole](kubernetes/apps/guacamole/guacamole) |
-| `home-automation` | [frigate](kubernetes/apps/home-automation/frigate), [grocy](kubernetes/apps/home-automation/grocy), [home-assistant](kubernetes/apps/home-automation/home-assistant), [mosquitto](kubernetes/apps/home-automation/mosquitto), [music-assistant](kubernetes/apps/home-automation/music-assistant), [printer-monitor](kubernetes/apps/home-automation/printer-monitor), [troy-backup](kubernetes/apps/home-automation/troy-backup), [zigbee2mqtt](kubernetes/apps/home-automation/zigbee2mqtt) |
+| `home-automation` | [frigate](kubernetes/apps/home-automation/frigate), [grocy](kubernetes/apps/home-automation/grocy), [home-assistant](kubernetes/apps/home-automation/home-assistant), [mealie](kubernetes/apps/home-automation/mealie), [mosquitto](kubernetes/apps/home-automation/mosquitto), [music-assistant](kubernetes/apps/home-automation/music-assistant), [printer-monitor](kubernetes/apps/home-automation/printer-monitor), [troy-backup](kubernetes/apps/home-automation/troy-backup), [zigbee2mqtt](kubernetes/apps/home-automation/zigbee2mqtt) |
 | `identity` | [authentik](kubernetes/apps/identity/authentik) |
 | `inference` | [ollama](kubernetes/apps/inference/ollama) |
 | `kube-system` | [descheduler](kubernetes/apps/kube-system/descheduler), [nfs-subdir-external-provisioner](kubernetes/apps/kube-system/nfs-subdir-external-provisioner), [reflector](kubernetes/apps/kube-system/reflector), [reloader](kubernetes/apps/kube-system/reloader) |

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   # Flux-Kustomizations
   - ./frigate/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./mealie/ks.yaml
   - ./mosquitto/ks.yaml
   - ./music-assistant/ks.yaml
   - ./printer-monitor/ks.yaml

--- a/kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mealie-backup
+  namespace: home-automation
+spec:
+  schedule: "15 3 * * *"
+  timeZone: America/Denver
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app: mealie-backup
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: k8s8
+          containers:
+            - name: backup
+              # Reuse the mealie image: it is already pulled on the node and
+              # ships the python sqlite3 module the online backup needs.
+              image: ghcr.io/mealie-recipes/mealie:v3.24.0
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  BACKUP_DIR=/nfs/mealie/backups
+                  mkdir -p "$BACKUP_DIR"
+                  STAMP=$(date +%Y%m%d_%H%M%S)
+                  FOUND=0
+                  for db in /app/data/*.db; do
+                    [ -e "$db" ] || continue
+                    FOUND=1
+                    dest="$BACKUP_DIR/$(basename "$db" .db)_${STAMP}.db"
+                    python3 - "$db" "$dest" <<'PY'
+                  import sqlite3
+                  import sys
+
+                  src = sqlite3.connect(sys.argv[1])
+                  dst = sqlite3.connect(sys.argv[2])
+                  with dst:
+                      src.backup(dst)
+                  result = dst.execute("PRAGMA integrity_check").fetchone()[0]
+                  dst.close()
+                  src.close()
+                  if result != "ok":
+                      raise SystemExit(f"integrity_check failed: {result}")
+                  print(f"backup verified: {sys.argv[2]}")
+                  PY
+                  done
+                  if [ "$FOUND" -eq 0 ]; then
+                    echo "ERROR: no sqlite database found under /app/data"
+                    exit 1
+                  fi
+                  find "$BACKUP_DIR" -name '*.db' -type f -mtime +14 -delete
+                  echo "backup complete"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              volumeMounts:
+                - name: data
+                  mountPath: /app/data
+                - name: nfs-backups
+                  mountPath: /nfs
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: mealie
+            - name: nfs-backups
+              nfs:
+                server: 192.168.20.210
+                path: /volume1/k8s

--- a/kubernetes/apps/home-automation/mealie/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mealie-secret
+  namespace: home-automation
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mealie-secret
+    template:
+      engineVersion: v2
+      data:
+        OIDC_CLIENT_SECRET: "{{ .MEALIE_CLIENT_SECRET }}"
+  data:
+    - secretKey: MEALIE_CLIENT_SECRET
+      remoteRef:
+        key: authentik-secrets
+        property: MEALIE_CLIENT_SECRET

--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mealie
+  namespace: home-automation
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: mealie
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      # SQLite lives on a local-path PVC, so the pod is pinned deliberately
+      # instead of letting the first schedule choose the node — and kept off
+      # the node that already hosts the cluster's other local-path volumes.
+      nodeSelector:
+        kubernetes.io/hostname: k8s8
+    controllers:
+      mealie:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/mealie-recipes/mealie
+              tag: v3.24.0
+              pullPolicy: IfNotPresent
+            env:
+              TZ: "America/Denver"
+              BASE_URL: "https://mealie.techvomit.xyz"
+              PUID: "1000"
+              PGID: "1000"
+              DB_ENGINE: sqlite
+              ALLOW_SIGNUP: "false"
+              # Traefik terminates TLS in-cluster; trust its forwarded
+              # headers so the OIDC redirect keeps the https scheme.
+              FORWARDED_ALLOW_IPS: "*"
+              OIDC_AUTH_ENABLED: "true"
+              OIDC_PROVIDER_NAME: "authentik"
+              OIDC_CONFIGURATION_URL: "https://auth.techvomit.xyz/application/o/mealie/.well-known/openid-configuration"
+              OIDC_CLIENT_ID: mealie
+              OIDC_SIGNUP_ENABLED: "true"
+              OIDC_USER_GROUP: "Mealie Users"
+              OIDC_ADMIN_GROUP: "Mealie Admins"
+              OIDC_AUTO_REDIRECT: "false"
+              OIDC_REMEMBER_ME: "true"
+            envFrom:
+              - secretRef:
+                  name: mealie-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+    service:
+      app:
+        controller: mealie
+        ports:
+          http:
+            port: 9000
+    ingress:
+      app:
+        className: ingress-traefik
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: mealie.techvomit.xyz
+        hosts:
+          - host: &host mealie.techvomit.xyz
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: techvomit-xyz-production-tls
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: local-path
+        globalMounts:
+          - path: /app/data

--- a/kubernetes/apps/home-automation/mealie/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+  - pairs:
+      app.kubernetes.io/name: mealie
+      app.kubernetes.io/instance: mealie
+namespace: home-automation
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./backup-cronjob.yaml

--- a/kubernetes/apps/home-automation/mealie/app/ocirepository.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mealie
+  namespace: home-automation
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home-automation/mealie/ks.yaml
+++ b/kubernetes/apps/home-automation/mealie/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mealie
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword
+  interval: 30m
+  path: ./kubernetes/apps/home-automation/mealie/app
+  prune: true
+  retryInterval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: *namespace
+  targetNamespace: home-automation
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
+++ b/kubernetes/apps/identity/authentik/app/authentik-oauth-blueprint.yaml
@@ -23,6 +23,7 @@ data:
       homeassistant_client_secret: !Env HOMEASSISTANT_CLIENT_SECRET
       synology_nas_client_secret: !Env SYNOLOGY_NAS_CLIENT_SECRET
       immich_client_secret: !Env IMMICH_CLIENT_SECRET
+      mealie_client_secret: !Env MEALIE_CLIENT_SECRET
     entries:
       # Groups for role mapping
       - model: authentik_core.group
@@ -152,6 +153,22 @@ data:
         state: present
         attrs:
           name: Music Assistant Users
+
+      - model: authentik_core.group
+        id: mealie-users
+        identifiers:
+          name: Mealie Users
+        state: present
+        attrs:
+          name: Mealie Users
+
+      - model: authentik_core.group
+        id: mealie-admins
+        identifiers:
+          name: Mealie Admins
+        state: present
+        attrs:
+          name: Mealie Admins
 
       # Custom Scope Mapping for Home Assistant groups and admin status
       - model: authentik_providers_oauth2.scopemapping
@@ -464,6 +481,37 @@ data:
           access_token_validity: "hours=1"
           refresh_token_validity: "days=30"
 
+      # OAuth2 Provider for Mealie
+      - model: authentik_providers_oauth2.oauth2provider
+        id: mealie-provider
+        identifiers:
+          name: Mealie
+        state: present
+        attrs:
+          name: Mealie
+          client_id: mealie
+          client_secret: !Context mealie_client_secret
+          client_type: confidential
+          # Shared with password-only users (amanda) — the passwordless flow has no
+          # password fallback and dead-ends anyone without a passkey.
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Internal JWT Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: "https://mealie.techvomit.xyz/login"
+            - matching_mode: strict
+              url: "https://mealie.techvomit.xyz/login?direct=1"
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+          sub_mode: hashed_user_id
+          access_code_validity: "minutes=1"
+          access_token_validity: "hours=1"
+          refresh_token_validity: "days=30"
+
       # Application for Grafana
       - model: authentik_core.application
         id: grafana-app
@@ -632,6 +680,20 @@ data:
           meta_description: "Music Assistant - Whole Home Audio"
           policy_engine_mode: any
 
+      # Application for Mealie
+      - model: authentik_core.application
+        id: mealie-app
+        identifiers:
+          slug: mealie
+        state: present
+        attrs:
+          name: Mealie
+          slug: mealie
+          provider: !KeyOf mealie-provider
+          meta_launch_url: "https://mealie.techvomit.xyz"
+          meta_description: "Mealie - Recipe Manager and Meal Planner"
+          policy_engine_mode: any
+
       # Expression policy for group checking
       - model: authentik_policies_expression.expressionpolicy
         id: traefik-admin-policy
@@ -742,6 +804,16 @@ data:
           name: music-assistant-user-policy
           expression: |
             return ak_is_group_member(request.user, name="Music Assistant Users")
+
+      - model: authentik_policies_expression.expressionpolicy
+        id: mealie-user-policy
+        identifiers:
+          name: mealie-user-policy
+        state: present
+        attrs:
+          name: mealie-user-policy
+          expression: |
+            return ak_is_group_member(request.user, name="Mealie Users") or ak_is_group_member(request.user, name="Mealie Admins")
 
       # Policy binding for Traefik application
       - model: authentik_policies.policybinding
@@ -858,6 +930,17 @@ data:
         identifiers:
           target: !KeyOf music-assistant-app
           policy: !KeyOf music-assistant-user-policy
+          order: 0
+        state: present
+        attrs:
+          enabled: true
+          order: 0
+
+      # Policy binding for Mealie application
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf mealie-app
+          policy: !KeyOf mealie-user-policy
           order: 0
         state: present
         attrs:

--- a/kubernetes/apps/identity/authentik/app/externalsecret.yaml
+++ b/kubernetes/apps/identity/authentik/app/externalsecret.yaml
@@ -32,6 +32,7 @@ spec:
         HOMEASSISTANT_CLIENT_SECRET: "{{ .HOMEASSISTANT_CLIENT_SECRET }}"
         SYNOLOGY_NAS_CLIENT_SECRET: "{{ .SYNOLOGY_NAS_CLIENT_SECRET }}"
         IMMICH_CLIENT_SECRET: "{{ .IMMICH_CLIENT_SECRET }}"
+        MEALIE_CLIENT_SECRET: "{{ .MEALIE_CLIENT_SECRET }}"
   dataFrom:
     - extract:
         key: authentik-secrets


### PR DESCRIPTION
**Key Changes:**

- Deployed Mealie v3.24.0 as a new Flux application in the `home-automation` namespace, backed by SQLite on a local-path PVC pinned to node k8s8
- Wired Mealie into Authentik as a confidential OAuth2 client with group-gated access (`Mealie Users` / `Mealie Admins`) and OIDC signup enabled
- Added a nightly CronJob that takes a verified online SQLite backup to NFS with 14-day retention, since local-path storage has no built-in redundancy

**Added:**

- Mealie application manifests - New `kubernetes/apps/home-automation/mealie/` tree with a Flux Kustomization (`ks.yaml`, depends on `onepassword`), an `app-template` 5.1.0 OCIRepository, and a HelmRelease exposing `mealie.techvomit.xyz` through the `ingress-traefik` class with the shared `techvomit-xyz-production-tls` cert; the pod carries a deliberate `nodeSelector` for k8s8 to keep it off the node already hosting the cluster's other local-path volumes, and sets `FORWARDED_ALLOW_IPS: "*"` so Traefik's forwarded headers preserve the https scheme on the OIDC redirect
- Nightly backup CronJob - `backup-cronjob.yaml` runs at 03:15 America/Denver on k8s8, reusing the Mealie image for its bundled python sqlite3 module; it uses the SQLite online backup API plus a `PRAGMA integrity_check` so a corrupt copy fails the job rather than silently landing on the NAS, writes to `/volume1/k8s` on 192.168.20.210, prunes copies older than 14 days, and exits non-zero when no database is found
- Mealie client secret plumbing - New ExternalSecret pulls `MEALIE_CLIENT_SECRET` from the `authentik-secrets` 1Password item into `OIDC_CLIENT_SECRET`, and the Authentik ExternalSecret template gained the matching key so the blueprint can resolve it
- Authentik OAuth2 provider, application, groups, and policy - Blueprint entries create the `Mealie` provider (strict redirect URIs for `/login` and `/login?direct=1`, `hashed_user_id` sub mode) on the standard authentication flow rather than the passwordless one, so password-only users are not dead-ended; plus the two role groups, a `mealie-user-policy` expression accepting either group, and its binding to the application

**Changed:**

- Test coverage for the new app - Added `home-automation/mealie/app` to both `TESTABLE_APPS` lists in `.taskfiles/test/Taskfile.yaml`
- Namespace and docs wiring - Registered `./mealie/ks.yaml` in the `home-automation` kustomization and regenerated the README app table (45 → 46 applications)