### PR TITLE
fix: disable OIDC email verification requirement for mealie

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -47,6 +47,10 @@ spec:
               # headers so the OIDC redirect keeps the https scheme.
               FORWARDED_ALLOW_IPS: "*"
               OIDC_AUTH_ENABLED: "true"
+              # This authentik's email scope does not emit the email_verified
+              # claim, which Mealie v3.21+ requires by default; account access
+              # is already gated by the Mealie Users group in authentik.
+              OIDC_REQUIRES_EMAIL_VERIFICATION: "false"
               OIDC_PROVIDER_NAME: "authentik"
               OIDC_CONFIGURATION_URL: "https://auth.techvomit.xyz/application/o/mealie/.well-known/openid-configuration"
               OIDC_CLIENT_ID: mealie


### PR DESCRIPTION
**Key Changes:**

- Disabled Mealie's default OIDC email verification requirement so authentik-backed logins succeed
- Documented that authentik's email scope omits the `email_verified` claim required by Mealie v3.21+
- Preserved access control via the existing Mealie Users group in authentik rather than claim-based gating

**Added:**

- `OIDC_REQUIRES_EMAIL_VERIFICATION: "false"` environment variable to the Mealie HelmRelease config block, alongside the existing OIDC settings - `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml`