### PR TITLE
fix: point mealie backups at the offsite-replicated photo share

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml
@@ -32,7 +32,7 @@ spec:
                 - -c
                 - |
                   set -eu
-                  BACKUP_DIR=/nfs/mealie/backups
+                  BACKUP_DIR=/nfs/mealie
                   mkdir -p "$BACKUP_DIR"
                   STAMP=$(date +%Y%m%d_%H%M%S)
                   FOUND=0
@@ -80,5 +80,8 @@ spec:
                 claimName: mealie
             - name: nfs-backups
               nfs:
+                # The photo share's backups dir is the one path the existing
+                # HyperBackup "Photos to B2" task actually replicates offsite;
+                # immich's database dumps land in the same tree.
                 server: 192.168.20.210
-                path: /volume1/k8s
+                path: /volume1/photo/backups


### PR DESCRIPTION
**Key Changes:**

- Redirected the mealie backup CronJob's NFS mount from `/volume1/k8s` to `/volume1/photo/backups`, the only share the existing HyperBackup "Photos to B2" task replicates offsite
- Flattened the in-container backup path from `/nfs/mealie/backups` to `/nfs/mealie` so dumps land directly under the photo share's backup tree alongside immich's database dumps

**Changed:**

- NFS volume source in `backup-cronjob.yaml` - the `nfs-backups` volume now mounts `/volume1/photo/backups` from 192.168.20.210 instead of `/volume1/k8s`, bringing mealie's sqlite dumps under offsite B2 replication
- Backup destination directory in the CronJob script - `BACKUP_DIR` changed to `/nfs/mealie` to avoid a redundant `backups` subdirectory now that the mount itself points at a backups tree
- Added an inline comment documenting why the photo share is the correct target, since the choice is non-obvious from the path alone