### PR TITLE
fix: broaden mealie backup contents and move dump ahead of offsite window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ node_modules
 
 # Local Claude Code config
 .claude/
+
+# unlazy pipeline state (local only)
+.unlazy/
+GATES.md

--- a/kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml
@@ -5,7 +5,10 @@ metadata:
   name: mealie-backup
   namespace: home-automation
 spec:
-  schedule: "15 3 * * *"
+  # HyperBackup snapshots /volume1/photo at ~03:00, so a 03:15 dump only
+  # ever replicated the following night. 02:30 puts each dump in that same
+  # morning's upload.
+  schedule: "30 2 * * *"
   timeZone: America/Denver
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
@@ -60,7 +63,20 @@ spec:
                     echo "ERROR: no sqlite database found under /app/data"
                     exit 1
                   fi
-                  find "$BACKUP_DIR" -name '*.db' -type f -mtime +14 -delete
+                  # The database alone cannot rebuild a working instance: recipe
+                  # images live on disk, and .secret / .session_secret sign the
+                  # issued API tokens, including the per-account planner tokens.
+                  assets="$BACKUP_DIR/assets_${STAMP}.tar.gz"
+                  tar -czf "$assets" -C /app/data \
+                    --exclude='./backups' \
+                    --exclude='*.db' \
+                    --exclude='*.log' \
+                    .
+                  tar -tzf "$assets" >/dev/null
+                  echo "assets verified: $assets"
+                  find "$BACKUP_DIR" \
+                    \( -name '*.db' -o -name 'assets_*.tar.gz' \) \
+                    -type f -mtime +14 -delete
                   echo "backup complete"
               resources:
                 requests:


### PR DESCRIPTION
**Key Changes:**

- Moved the mealie backup CronJob from 03:15 to 02:30 America/Denver so each dump lands in the same morning's HyperBackup upload of `/volume1/photo` instead of waiting a full extra day for offsite replication
- Backups now capture the full `/app/data` tree (recipe images, `.secret`, `.session_secret`) alongside the sqlite dump — the database alone cannot rebuild a working instance, and the signing secrets back the issued API tokens including per-account planner tokens
- Added verification of the assets archive with `tar -tzf` before the job reports success

**Added:**

- Asset tarball step in the backup CronJob — `tar -czf assets_${STAMP}.tar.gz` over `/app/data`, excluding `./backups`, `*.db`, and `*.log`, with an integrity read-back and a log line naming the archive - `kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml`
- Local-only ignore entries for `.unlazy/` pipeline state and `GATES.md` - `.gitignore`

**Changed:**

- CronJob schedule from `15 3 * * *` to `30 2 * * *`, with a comment recording the offsite-window reasoning - `kubernetes/apps/home-automation/mealie/app/backup-cronjob.yaml`
- Retention pruning now sweeps both `*.db` and `assets_*.tar.gz` files older than 14 days, so the new archives age out on the same cadence as the database dumps