### PR TITLE
chore: ignore local household meal specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ node_modules
 # unlazy pipeline state (local only)
 .unlazy/
 GATES.md
+
+# Household meal specs stay local: they carry personal household detail
+# and this repository is public. Deliberate - do not un-ignore.
+spec/


### PR DESCRIPTION
**Key Changes:**

- Added a `spec/` ignore rule so household meal specifications stay on local disk and never reach this public repository
- Documented the reasoning inline so the entry is not mistaken for an accidental exclusion and removed later

**Added:**

- `spec/` ignore entry with an explanatory comment — `.gitignore` now excludes the directory because the meal specs carry personal household detail that should not be published alongside this repo's public content