### PR TITLE
fix: replace grocy readiness probe with body-inspecting exec check

### DIFF
--- a/kubernetes/apps/home-automation/grocy/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/grocy/app/helmrelease.yaml
@@ -32,7 +32,6 @@ spec:
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"
-              GROCY_CULTURE: "en"
               GROCY_CURRENCY: "USD"
               GROCY_MODE: production
               PUID: "1000"
@@ -44,15 +43,26 @@ spec:
               PHP_OPCACHE_MEMORY_CONSUMPTION: "128"
               PHP_OPCACHE_MAX_ACCELERATED_FILES: "10000"
               PHP_OPCACHE_VALIDATE_TIMESTAMPS: "0"
-              # SQLite optimizations
-              GROCY_DATABASE_PRAGMA_JOURNAL_MODE: "WAL"
-              GROCY_DATABASE_PRAGMA_SYNCHRONOUS: "NORMAL"
-              GROCY_DATABASE_PRAGMA_CACHE_SIZE: "-64000"
             probes:
               liveness:
                 enabled: true
               readiness:
                 enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >-
+                        b=$(curl -fsS -L --max-time 4 http://localhost/login) &&
+                        printf '%s' "$b" | grep -qF 'grocy.css' &&
+                        printf '%s' "$b" | grep -qF '</html>'
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+                  successThreshold: 1
               startup:
                 enabled: true
             resources:


### PR DESCRIPTION
**Key Changes:**

- Replaced the default HTTP readiness probe with a custom exec probe that fetches `/login` and asserts the response body actually contains rendered page markup (`grocy.css` and a closing `</html>`), so a socket that accepts connections but serves a broken or truncated page no longer reports Ready
- Dropped SQLite PRAGMA tuning env vars that were being passed to the container without effect
- Removed the redundant `GROCY_CULTURE` env var

**Changed:**

- Readiness gating for grocy - Switched to `custom: true` with an inline exec spec (`curl -fsS -L --max-time 4` piped through two `grep -qF` content assertions), tuned with `initialDelaySeconds: 0`, `periodSeconds: 10`, `timeoutSeconds: 5`, `failureThreshold: 3`, and `successThreshold: 1` in `kubernetes/apps/home-automation/grocy/app/helmrelease.yaml`

**Removed:**

- SQLite optimization env vars - Deleted `GROCY_DATABASE_PRAGMA_JOURNAL_MODE`, `GROCY_DATABASE_PRAGMA_SYNCHRONOUS`, and `GROCY_DATABASE_PRAGMA_CACHE_SIZE` from the container environment
- Locale override - Deleted `GROCY_CULTURE: "en"`, leaving the image default in place