### PR TITLE
chore: switch mealie to the cowdogmoo fork image

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -33,8 +33,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/mealie-recipes/mealie
-              tag: v3.24.0
+              repository: ghcr.io/cowdogmoo/mealie
+              tag: v3.24.0-woe.1
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"

--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.1
+              tag: v3.24.0-woe.dev.8942dce
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Repointed the Mealie container from the upstream `ghcr.io/mealie-recipes/mealie` image to the `ghcr.io/cowdogmoo/mealie` fork
- Pinned the fork to the explicit dev build tag `v3.24.0-woe.dev.8942dce` rather than a floating tag, keeping `imagePullPolicy: IfNotPresent` intact

**Changed:**

- Mealie image source and tag - Updated the `app` container image in `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml` to pull the cowdogmoo fork at `v3.24.0-woe.dev.8942dce`, replacing upstream `v3.24.0`