### PR TITLE
chore: pin mealie image to release tag v3.24.0-woe.1

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.dev.8942dce
+              tag: v3.24.0-woe.1
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Replaced the mutable dev-build image reference with an immutable release tag, making the deployed mealie version reproducible across reconciles
- Moved the `ghcr.io/cowdogmoo/mealie` container off a commit-SHA-suffixed dev build and onto the published `v3.24.0-woe.1` release

**Changed:**

- Mealie image tag pinned from `v3.24.0-woe.dev.8942dce` to `v3.24.0-woe.1` in the HelmRelease values, so the running image comes from a tagged release rather than an ad-hoc dev build tied to a single commit — `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml`