### PR TITLE
fix: extend mealie session lifetime to 14 days

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.1
+              tag: v3.24.0-woe.2
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"
@@ -43,6 +43,9 @@ spec:
               PGID: "1000"
               DB_ENGINE: sqlite
               ALLOW_SIGNUP: "false"
+              # Session length, in hours. The cookie is persisted for as long as
+              # the token is valid, so this is how long OIDC_REMEMBER_ME remembers.
+              TOKEN_TIME: "336"
               # Traefik terminates TLS in-cluster; trust its forwarded
               # headers so the OIDC redirect keeps the https scheme.
               FORWARDED_ALLOW_IPS: "*"


### PR DESCRIPTION
**Key Changes:**

- Set `TOKEN_TIME` to 336 hours so Mealie sessions survive for two weeks instead of the 48-hour default, matching the lifetime of the JWT that OIDC remember-me mints
- Bumped the custom Mealie image to `v3.24.0-woe.2` to pick up the build that carries this session behavior

**Changed:**

- Session lifetime configuration - Added `TOKEN_TIME: "336"` to the app environment in `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml`, with an inline note that the session cookie is persisted for exactly as long as the token is valid, so this value is what governs how long OIDC remember-me actually remembers
- Image tag - Advanced `ghcr.io/cowdogmoo/mealie` from `v3.24.0-woe.1` to `v3.24.0-woe.2`, keeping `pullPolicy: IfNotPresent`