### PR TITLE
chore: bump mealie image to v3.24.0-woe.3

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.2
+              tag: v3.24.0-woe.3
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Bumped the pinned Mealie fork image from `v3.24.0-woe.2` to `v3.24.0-woe.3`

**Changed:**

- Mealie container image tag - Updated the `ghcr.io/cowdogmoo/mealie` tag to `v3.24.0-woe.3` in the app's HelmRelease values, keeping `pullPolicy: IfNotPresent` and the explicit version pin rather than a floating tag