### PR TITLE
chore: bump mealie image to v3.24.0-woe.4

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.3
+              tag: v3.24.0-woe.4
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Bumped the Mealie container image tag from `v3.24.0-woe.3` to `v3.24.0-woe.4` to pick up the latest fork build

**Changed:**

- Mealie image tag - Updated `ghcr.io/cowdogmoo/mealie` to `v3.24.0-woe.4` in the app container spec, leaving `pullPolicy: IfNotPresent` and the rest of the HelmRelease values untouched