### PR TITLE
feat: add dinner-planner runner deployment to home-automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ woe/
 
 <!-- BEGIN GENERATED: apps -->
 
-Flux reconciles **46 applications** across **17 namespaces** from [`kubernetes/apps/`](kubernetes/apps).
+Flux reconciles **47 applications** across **17 namespaces** from [`kubernetes/apps/`](kubernetes/apps).
 
 | Namespace | Applications |
 | --------- | ------------ |
@@ -231,7 +231,7 @@ Flux reconciles **46 applications** across **17 namespaces** from [`kubernetes/a
 | `external-secrets` | [external-secrets](kubernetes/apps/external-secrets/external-secrets), [onepassword](kubernetes/apps/external-secrets/onepassword) |
 | `flux-system` | [addons](kubernetes/apps/flux-system/addons), [flux-instance](kubernetes/apps/flux-system/flux-instance), [flux-operator](kubernetes/apps/flux-system/flux-operator), [weave-gitops](kubernetes/apps/flux-system/weave-gitops) |
 | `guacamole` | [guacamole](kubernetes/apps/guacamole/guacamole) |
-| `home-automation` | [frigate](kubernetes/apps/home-automation/frigate), [grocy](kubernetes/apps/home-automation/grocy), [home-assistant](kubernetes/apps/home-automation/home-assistant), [mealie](kubernetes/apps/home-automation/mealie), [mosquitto](kubernetes/apps/home-automation/mosquitto), [music-assistant](kubernetes/apps/home-automation/music-assistant), [printer-monitor](kubernetes/apps/home-automation/printer-monitor), [troy-backup](kubernetes/apps/home-automation/troy-backup), [zigbee2mqtt](kubernetes/apps/home-automation/zigbee2mqtt) |
+| `home-automation` | [dinner-planner](kubernetes/apps/home-automation/dinner-planner), [frigate](kubernetes/apps/home-automation/frigate), [grocy](kubernetes/apps/home-automation/grocy), [home-assistant](kubernetes/apps/home-automation/home-assistant), [mealie](kubernetes/apps/home-automation/mealie), [mosquitto](kubernetes/apps/home-automation/mosquitto), [music-assistant](kubernetes/apps/home-automation/music-assistant), [printer-monitor](kubernetes/apps/home-automation/printer-monitor), [troy-backup](kubernetes/apps/home-automation/troy-backup), [zigbee2mqtt](kubernetes/apps/home-automation/zigbee2mqtt) |
 | `identity` | [authentik](kubernetes/apps/identity/authentik) |
 | `inference` | [ollama](kubernetes/apps/inference/ollama) |
 | `kube-system` | [descheduler](kubernetes/apps/kube-system/descheduler), [nfs-subdir-external-provisioner](kubernetes/apps/kube-system/nfs-subdir-external-provisioner), [reflector](kubernetes/apps/kube-system/reflector), [reloader](kubernetes/apps/kube-system/reloader) |

--- a/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
@@ -1,0 +1,89 @@
+---
+# The dinner-refill runner: the loop that used to be a launchd agent on a
+# laptop. Every five minutes it folds the household's Mealie feedback into the
+# planner's history, drains the Home Assistant swap queue, and refills the
+# recipe box for every thumbs-down that condemned no night - handing the one
+# judgement call (which recipe) to the dinner-refill squad agent on squad's
+# claude-code provider.
+#
+# A Deployment with one replica and a sleep loop, not a CronJob: the planner
+# state on the volume is read and written through `kubectl exec` when a week is
+# planned from the laptop, and a tick that is still filling a night must never
+# be overlapped by the next.
+#
+# The image tag is a commit of l50/personal-skills, never a floating name.
+# Bumping it is a reviewed commit here.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dinner-planner-runner
+  namespace: home-automation
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dinner-planner-runner
+  template:
+    metadata:
+      labels:
+        app: dinner-planner-runner
+    spec:
+      # Pinned with mealie: the state volume is local-path on this node.
+      nodeSelector:
+        kubernetes.io/hostname: k8s8
+      imagePullSecrets:
+        - name: dinner-planner-ghcr
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+      containers:
+        - name: runner
+          image: ghcr.io/l50/dinner-runner:e2eeeb083a50d109a1e98f26bb3272004c1b5ea7
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: dinner-planner
+          env:
+            # API calls stay inside the cluster; links in pushes use the public
+            # host, which is what MEALIE_URL is for.
+            - name: MEALIE_URL
+              value: https://mealie.techvomit.xyz
+            - name: MEALIE_API_URL
+              value: http://mealie.home-automation.svc.cluster.local:9000
+            - name: HA_URL
+              value: http://home-assistant.home-automation.svc.cluster.local:8123
+            - name: SWAP_RUNNER_INTERVAL
+              value: "300"
+            - name: SWAP_RUNNER_SEARCH
+              value: squad
+            - name: SWAP_RUNNER_MAX_COST
+              value: "5"
+          volumeMounts:
+            - name: state
+              mountPath: /home/node/.local/state
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          livenessProbe:
+            # The runner writes a heartbeat only when a tick really reached
+            # Home Assistant. Two missed ticks and the pod is restarted.
+            exec:
+              command:
+                - sh
+                - -c
+                - test "$(find /home/node/.local/state/meal-planner -maxdepth 1 -name swap-runner.heartbeat -mmin -12 | wc -l)" -ge 1
+            initialDelaySeconds: 120
+            periodSeconds: 120
+            failureThreshold: 3
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: dinner-planner-state

--- a/kubernetes/apps/home-automation/dinner-planner/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/externalsecret.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# Every token the runner needs, from the automation vault. The planner scripts
+# read these from the environment before they would ever reach for `op`, and
+# the image carries no `op` at all, so this Secret is the runner's only way in.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dinner-planner
+  namespace: home-automation
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dinner-planner
+    template:
+      engineVersion: v2
+      data:
+        HA_TOKEN: "{{ .HA_TOKEN }}"
+        MEALIE_TOKEN_JAYSON: "{{ .MEALIE_TOKEN_JAYSON }}"
+        MEALIE_TOKEN_AMANDA: "{{ .MEALIE_TOKEN_AMANDA }}"
+        # A long-lived Claude Code token from `claude setup-token`, so squad's
+        # claude-code provider bills the subscription, not an API key.
+        CLAUDE_CODE_OAUTH_TOKEN: "{{ .CLAUDE_CODE_OAUTH_TOKEN }}"
+  data:
+    - secretKey: HA_TOKEN
+      remoteRef:
+        key: Home Assistant
+        property: debug-token
+    - secretKey: MEALIE_TOKEN_JAYSON
+      remoteRef:
+        key: mealie-api-tokens
+        property: jayson-planner
+    - secretKey: MEALIE_TOKEN_AMANDA
+      remoteRef:
+        key: mealie-api-tokens
+        property: amanda-planner
+    - secretKey: CLAUDE_CODE_OAUTH_TOKEN
+      remoteRef:
+        key: claude-code
+        property: oauth-token
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# ghcr.io/l50/dinner-runner is built from a private repository, so the package
+# is private and the kubelet needs a read:packages token to pull it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dinner-planner-ghcr
+  namespace: home-automation
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dinner-planner-ghcr
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"{{ .username }}","password":"{{ .token }}","auth":"{{ printf "%s:%s" .username .token | b64enc }}"}}}
+  data:
+    - secretKey: username
+      remoteRef:
+        key: ghcr-pull
+        property: username
+    - secretKey: token
+      remoteRef:
+        key: ghcr-pull
+        property: token

--- a/kubernetes/apps/home-automation/dinner-planner/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+  - pairs:
+      app.kubernetes.io/name: dinner-planner
+      app.kubernetes.io/instance: dinner-planner
+namespace: home-automation
+resources:
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./deployment.yaml

--- a/kubernetes/apps/home-automation/dinner-planner/app/pvc.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/pvc.yaml
@@ -1,0 +1,18 @@
+---
+# The planner's memory: history.json (every recipe proposed, every vote,
+# every block, the refill and swap queues) and the recipe-finding skill's own
+# history of what it has already returned. Small, but it is the only copy the
+# household has of what it said about dinner, so it is a volume and not an
+# emptyDir. local-path on k8s8, the node the runner is pinned to.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dinner-planner-state
+  namespace: home-automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/home-automation/dinner-planner/ks.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dinner-planner
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword
+    - name: mealie
+  interval: 30m
+  path: ./kubernetes/apps/home-automation/dinner-planner/app
+  prune: true
+  retryInterval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: *namespace
+  targetNamespace: home-automation
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./dinner-planner/ks.yaml
   - ./frigate/ks.yaml
   - ./home-assistant/ks.yaml
   - ./mealie/ks.yaml


### PR DESCRIPTION
**Key Changes:**

- Deployed the dinner-refill runner as a single-replica Deployment in `home-automation`, replacing the laptop launchd agent that previously ran the five-minute loop folding Mealie feedback into planner history, draining the Home Assistant swap queue, and refilling the recipe box
- Wired every runner credential through External Secrets from the 1Password automation vault, including a `dockerconfigjson` pull secret so the kubelet can pull the private `ghcr.io/l50/dinner-runner` image
- Persisted planner state (history.json, recipe-finder history) on a 1Gi `local-path` PVC with the pod pinned to k8s8 alongside mealie
- Registered the app with Flux via a new Kustomization depending on `onepassword` and `mealie`

**Added:**

- Runner workload - `deployment.yaml` defines a `Recreate`-strategy Deployment with one replica, a digest-style image tag pinned to an `l50/personal-skills` commit, non-root securityContext (uid/gid/fsGroup 1000), in-cluster service URLs for the Mealie API and Home Assistant plus the public `MEALIE_URL` for links in pushes, swap-runner tuning env (`SWAP_RUNNER_INTERVAL`, `SWAP_RUNNER_SEARCH`, `SWAP_RUNNER_MAX_COST`), 100m/512Mi requests against 2 CPU/2Gi limits, and an exec livenessProbe that restarts the pod when the `swap-runner.heartbeat` file goes stale past ~12 minutes
- Secret plumbing - `externalsecret.yaml` adds a `dinner-planner` ExternalSecret pulling `HA_TOKEN`, per-person Mealie API tokens for jayson and amanda, and a `CLAUDE_CODE_OAUTH_TOKEN` so squad's claude-code provider bills the subscription rather than an API key, plus a `dinner-planner-ghcr` ExternalSecret rendering a `kubernetes.io/dockerconfigjson` from a `read:packages` username/token pair
- State volume - `pvc.yaml` requests a 1Gi ReadWriteOnce `local-path` claim named `dinner-planner-state`, mounted at `/home/node/.local/state`, since it holds the only copy of the household's planning history
- Flux wiring - `ks.yaml` reconciles `./kubernetes/apps/home-automation/dinner-planner/app` every 30m with `prune: true`, `wait: false`, a 1m retryInterval, and a 5m timeout; `app/kustomization.yaml` sets the shared `app.kubernetes.io/name`/`instance` labels across the three resources

**Changed:**

- App registration - `kubernetes/apps/home-automation/kustomization.yaml` now includes `./dinner-planner/ks.yaml` in the Flux-Kustomizations list
- Generated inventory - `README.md` reflects 47 applications instead of 46 and lists `dinner-planner` first in the `home-automation` namespace row