### PR TITLE
chore: bump dinner-runner image to 35254082

### DIFF
--- a/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: runner
-          image: ghcr.io/l50/dinner-runner:e2eeeb083a50d109a1e98f26bb3272004c1b5ea7
+          image: ghcr.io/l50/dinner-runner:35254082ea0ce9e55b0a25a68cbac7434e08109c
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
**Key Changes:**

- Updated the dinner-runner container image for the dinner-planner deployment to digest-pinned tag `35254082ea0ce9e55b0a25a68cbac7434e08109c`, picking up the latest build of the runner

**Changed:**

- Runner container image tag advanced from `e2eeeb083a50d109a1e98f26bb3272004c1b5ea7` to `35254082ea0ce9e55b0a25a68cbac7434e08109c` in the dinner-planner deployment; `imagePullPolicy: IfNotPresent` is unchanged, so the new SHA tag is what triggers the pull - `kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml`