### PR TITLE
chore: bump dinner-runner image to 5f90547

### DIFF
--- a/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: runner
-          image: ghcr.io/l50/dinner-runner:35254082ea0ce9e55b0a25a68cbac7434e08109c
+          image: ghcr.io/l50/dinner-runner:5f90547698756ab88385ebdf0a60100611eb44c9
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
**Key Changes:**

- Updated the dinner-planner runner container to a newer `dinner-runner` image build

**Changed:**

- Runner image pin advanced from digest-tagged `35254082ea0ce9e55b0a25a68cbac7434e08109c` to `5f90547698756ab88385ebdf0a60100611eb44c9` in the home-automation dinner-planner deployment, keeping `imagePullPolicy: IfNotPresent` and the rest of the pod spec unchanged