### PR TITLE
chore: bump mealie image to v3.24.0-woe.5

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.4
+              tag: v3.24.0-woe.5
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Bumped the Mealie container image tag from `v3.24.0-woe.4` to `v3.24.0-woe.5` in the app's HelmRelease

**Changed:**

- Mealie image tag - Updated the `ghcr.io/cowdogmoo/mealie` tag to `v3.24.0-woe.5` in `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml`, leaving `pullPolicy: IfNotPresent` and the rest of the release values untouched