### PR TITLE
chore: bump mealie image to v3.24.0-woe.6

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.5
+              tag: v3.24.0-woe.6
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Updated the Mealie container image tag from `v3.24.0-woe.5` to `v3.24.0-woe.6` in the home-automation HelmRelease

**Changed:**

- Mealie image tag - Bumped `ghcr.io/cowdogmoo/mealie` to `v3.24.0-woe.6` in `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml`, leaving `pullPolicy: IfNotPresent` and the rest of the release values untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)