### PR TITLE
chore: bump dinner-runner image to 14997ad

### DIFF
--- a/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: runner
-          image: ghcr.io/l50/dinner-runner:5f90547698756ab88385ebdf0a60100611eb44c9
+          image: ghcr.io/l50/dinner-runner:14997ad5e6c4c77343cd81c5260568684111775a
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
**Key Changes:**

- Updated the dinner-planner runner container to a newer `dinner-runner` build, pinned by full commit SHA
- No other manifest fields (pull policy, security context, env sources) were altered

**Changed:**

- dinner-planner runner image tag - Bumped `ghcr.io/l50/dinner-runner` from `5f90547698756ab88385ebdf0a60100611eb44c9` to `14997ad5e6c4c77343cd81c5260568684111775a` in the deployment's `runner` container

🤖 Generated with [Claude Code](https://claude.com/claude-code)