### PR TITLE
chore: bump mealie image to v3.24.0-woe.7

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.6
+              tag: v3.24.0-woe.7
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Upgraded the Mealie deployment to the `v3.24.0-woe.7` fork build of `ghcr.io/cowdogmoo/mealie`

**Changed:**

- Mealie container image tag - bumped from `v3.24.0-woe.6` to `v3.24.0-woe.7` in the app values of `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml`, leaving `pullPolicy: IfNotPresent` and the surrounding env configuration untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)