### PR TITLE
chore: bump mealie image to v3.24.0-woe.8

### DIFF
--- a/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mealie/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/cowdogmoo/mealie
-              tag: v3.24.0-woe.7
+              tag: v3.24.0-woe.8
               pullPolicy: IfNotPresent
             env:
               TZ: "America/Denver"


### PR DESCRIPTION
**Key Changes:**

- Upgraded the Mealie container image from `v3.24.0-woe.8` predecessor `v3.24.0-woe.7` to pick up the latest fork build
- Single-line tag change in the Mealie HelmRelease; no chart values, env, or deployment topology altered

**Changed:**

- Mealie image tag - Bumped `ghcr.io/cowdogmoo/mealie` from `v3.24.0-woe.7` to `v3.24.0-woe.8` in the app image block of `kubernetes/apps/home-automation/mealie/app/helmrelease.yaml`, leaving `pullPolicy: IfNotPresent` and the surrounding `TZ` env configuration untouched