### PR TITLE
chore: bump dinner-runner image to f994711

### DIFF
--- a/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: runner
-          image: ghcr.io/l50/dinner-runner:14997ad5e6c4c77343cd81c5260568684111775a
+          image: ghcr.io/l50/dinner-runner:f99471127f0a4401c0e023a83620faceac4795b6
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
**Key Changes:**

- Updated the `dinner-runner` container image tag from `14997ad` to `f994711` in the dinner-planner deployment, rolling the runner onto the newer build

**Changed:**

- Runner container image pin — `kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml` now references `ghcr.io/l50/dinner-runner:f99471127f0a4401c0e023a83620faceac4795b6` instead of the prior `14997ad5e6c4c77343cd81c5260568684111775a` digest-style tag, keeping `imagePullPolicy: IfNotPresent` and the rest of the pod spec untouched