### PR TITLE
chore: bump dinner-runner image to 3133b69

### DIFF
--- a/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
+++ b/kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: runner
-          image: ghcr.io/l50/dinner-runner:f99471127f0a4401c0e023a83620faceac4795b6
+          image: ghcr.io/l50/dinner-runner:3133b696c2a4e7c455935a69383ad6c615b74054
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
**Key Changes:**

- Updated the dinner-runner container image tag from `f994711` to `3133b69`, rolling the deployment onto the newer build

**Changed:**

- Pinned dinner-runner image digest-style tag advanced to `3133b696c2a4e7c455935a69383ad6c615b74054` - `kubernetes/apps/home-automation/dinner-planner/app/deployment.yaml`